### PR TITLE
docs: Claude Code 세션 인계용 CLAUDE.md·MEMORY.md 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# Image Converter
+
+PNG/JPG/JPEG 이미지를 WebP/AVIF 로 변환하는 Rust CLI 도구.
+
+## 프로젝트 개요
+
+- **언어/도구**: Rust (edition 2021)
+- **지원**: 단일 파일 변환 + 디렉토리 일괄 변환 (재귀 옵션)
+- **인터페이스**: 명령줄 모드 (`-i/-o/-f/-q/-r`) + 대화형 모드 (`-I`)
+- **변환 엔진**: WebP는 `webp` 크레이트, AVIF는 `ravif` (rav1e 기반)
+
+세부 사용법은 `README.md` 참고.
+
+## 모듈 구조
+
+```
+src/
+├── main.rs            # CLI 진입점, 단일/일괄 분기
+├── lib.rs             # 공개 API re-export (main.rs도 이 lib을 통해 import)
+├── converter.rs       # 단일 변환. encode_to() 헬퍼를 통해
+│                      # convert_image(UI 포함) / convert_image_silent(조용함) 가
+│                      # 동일 내부를 공유
+├── batch.rs           # 디렉토리 일괄 변환 (walkdir 기반, 재귀 옵션, 구조 미러링)
+├── interactive.rs     # 대화형 모드 (단일/디렉토리 선택 → 옵션 → 실행)
+├── utils.rs           # format_file_size 등 헬퍼
+└── tests/             # 단위 + 통합 테스트 (총 12개)
+```
+
+세부 책임은 `PROJECT_STRUCTURE.md` 참고.
+
+## 시스템 요구사항
+
+- **Rust toolchain** (cargo 1.94+)
+- **nasm** — AVIF 인코더(`rav1e`) 빌드에 필요. WSL/Ubuntu 에서:
+  ```bash
+  sudo apt-get install -y nasm
+  ```
+
+## 개발 명령어
+
+```bash
+# 빌드
+cargo build              # 디버그
+cargo build --release    # 릴리즈 (실제 변환 속도 측정/사용 시)
+
+# 테스트
+cargo test                              # 기본
+cargo test --release                    # 릴리즈 모드 (AVIF 테스트가 빠름)
+cargo test -- --test-threads=1 --nocapture  # 출력 깔끔하게 (TESTING.md 추천)
+cargo test test_batch                   # 일괄 변환 테스트만
+
+# 실행 (릴리즈)
+./target/release/image_converter -I                          # 대화형
+./target/release/image_converter -i a.png -o a.webp -f webp  # 단일
+./target/release/image_converter -i photos -o out -f webp -r # 디렉토리 재귀
+```
+
+## 코드 컨벤션
+
+- **언어**
+  - 사용자 향 출력 (CLI 메시지, 에러, 진행 안내), 주석, 문서, 커밋 메시지: **한국어**
+  - 함수/변수/타입 식별자, 외부 API 이름: 영어
+  - 한국어 안에 영어 고유명사·기술용어·심볼은 그대로 (예: `WebP 인코더 생성 중...`)
+- **이모지**
+  - CLI 출력과 README 예제에서 의미 있는 시각 단서로 사용 (`🚀 시작`, `✅ 성공`, `❌ 실패`, `📁 입력`, `💾 출력`)
+  - 코드 주석/내부 로그에는 사용하지 않음
+- **에러 처리**
+  - 현재 `Result<T, Box<dyn std::error::Error>>` 사용
+  - 향후 `thiserror` 기반 커스텀 에러 타입으로 마이그레이션 예정
+- **테스트 출력**
+  - `test_description!`, `test_step!`, `test_success!` 매크로로 가독성 있는 로그 (정의: `src/tests/test_utils.rs`)
+  - 통합 테스트는 `tempfile` 로 격리
+
+## 커밋 컨벤션
+
+Conventional Commits + 한국어 본문.
+
+```
+<type>: <한국어 제목>
+
+- 변경 내용 1
+- 변경 내용 2
+
+Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+**type**: `feat` · `fix` · `refactor` · `chore` · `docs` · `style` · `test` · `perf` · `ci` · `build` · `revert` · `init` · `remove` · `rename` · `hotfix`
+
+**규칙**
+- 제목은 type 뒤 한국어. 영어 고유명사/기술용어/심볼은 그대로
+- 본문은 `-` 리스트, 백틱으로 코드/심볼 인용 가능
+- 마지막 줄에 `Co-authored-by:` (소문자 `a`/`b`) 트레일러 — Claude Code 기본 템플릿(`Co-Authored-By` 대문자) 대신 이 형식 우선
+- PR squash merge 시 제목 끝에 `(#N)` 자동 부착
+
+## 향후 개선 후보
+
+(우선순위 추정 순)
+
+1. **clap v4 마이그레이션** — 현재 v3.2.x. 문법이 꽤 달라짐 (`App` → `Command` 등)
+2. **커스텀 에러 타입** — `thiserror` 도입, `Box<dyn Error>` 제거
+3. **일괄 변환 병렬화** — `rayon` 으로 멀티코어 활용 (큰 폴더에서 효과 큼)
+4. **다양한 입력 확장자 회귀 테스트** — JPG/JPEG 명시 케이스 추가
+5. **대화형 모드 테스트** — 현재 미커버
+6. **다국어/메시지 분리** — 메시지를 별도 파일/리소스로
+
+## 관련 문서
+
+- `README.md` — 사용자용 사용법, 옵션, 예제 출력
+- `PROJECT_STRUCTURE.md` — 모듈별 책임, 의존성 흐름, 향후 개선 제안
+- `TESTING.md` — 테스트 실행 방법, 테스트 목록 (12개), 매크로 사용법
+- `MEMORY.md` — 작업 컨텍스트, 결정 기록, 진행 중/대기 항목 (세션 간 인계용)

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,44 @@
+# Memory
+
+세션 간 인계용 작업 컨텍스트. 정적 컨벤션과 구조는 `CLAUDE.md` 에 있고, 여기는 **시간에 따라 변하는 것** (최근 변경, 결정 기록, 진행/대기 항목) 만 기록.
+
+새 세션에서 일을 이어 받을 때 이 파일을 읽으면 어디서 멈췄는지 빠르게 파악할 수 있도록.
+
+## 사용자 컨텍스트
+
+- 한국어 사용자
+- 모든 출력 (응답·코드 주석·문서·커밋·CLI 메시지) 한국어로 작성
+- 커밋 형식은 `CLAUDE.md` 의 "커밋 컨벤션" 섹션을 따름
+
+## 최근 작업 로그
+
+### 2026-04-30 — `feat: 디렉토리 일괄 변환 모드 추가` (PR #5, merged)
+
+- 신규 `src/batch.rs` 모듈 — `walkdir` 기반 디렉토리 순회, `BatchSummary` 통계 반환
+- `src/converter.rs` 리팩토링 — `encode_to()` 헬퍼 분리로 `convert_image` / `convert_image_silent` 가 동일 내부 공유
+- `lib.rs` 의 중복 `convert_image_silent` 정의 제거, `main.rs` 가 lib을 통해 import (bin/lib 중복 컴파일 제거)
+- CLI: 입력 경로가 디렉토리이면 자동 일괄 모드, `-r/--recursive` 추가
+- 대화형 모드: 첫 단계에 단일/디렉토리 선택, 디렉토리 모드에서 재귀 여부 질문
+- 통합 테스트 5개 추가 (총 7→12, 모두 통과)
+- `walkdir = "2.5"` 추가
+- README/PROJECT_STRUCTURE/TESTING 문서 갱신
+
+## 결정 기록
+
+- **`walkdir` 채택** — 재귀+필터 조합을 std `read_dir` 로만 처리하면 verbose 함. 비재귀에도 `WalkDir::new(path).max_depth(1)` 로 통일하여 코드 분기 단순화.
+- **`encode_to()` 헬퍼 분리** — 단일 변환의 UI 포함 버전과 조용한 버전, 그리고 일괄 변환에서 호출되는 inner 까지 세 곳이 동일 인코딩 로직을 쓰는 상황. 헬퍼로 분리하여 한 군데에서만 유지.
+- **`convert_image_silent` 의 반환 타입을 `()` → `ConvertStats`** — 일괄 모드의 합계 통계 계산을 위해. 기존 테스트는 `?` 로만 결과를 처리해서 시그니처 변경에 영향 없음.
+- **bin/lib 중복 컴파일 제거** — `main.rs` 가 `mod converter;` 등으로 모듈을 직접 포함하면 lib 과 bin 양쪽에서 같은 코드가 컴파일되고 `convert_image_silent` 가 bin 측에서 dead_code 경고. `main.rs` 를 `image_converter::*` 로 import 하도록 변경하여 해결.
+
+## 진행 중 / 대기
+
+- [ ] **clap v4 마이그레이션** — 다음 PR 후보. `App` → `Command` 등 문법 변경 폭이 있음.
+- [ ] **커스텀 에러 타입 (`thiserror`)** — clap v4 와 함께 같은 PR로 묶을지 별도로 갈지 결정 필요. (제안: 별도 PR, 변경 범위가 다름)
+- [ ] **일괄 변환 병렬화 (`rayon`)** — 위 두 개 끝난 후. 진행률 바를 멀티스레드 친화적으로 바꾸는 작업이 같이 필요.
+- [ ] **JPG/JPEG 입력 명시 회귀 테스트** — 현재 PNG 만 명시 테스트. 작은 추가 작업.
+- [ ] **대화형 모드 테스트** — `dialoguer` 입력 모킹이 까다로워 우선순위 낮음.
+
+## 환경 메모
+
+- WSL2 (Ubuntu) 에서 빌드 시 `nasm` 패키지 필요 (rav1e/AVIF). `sudo apt-get install -y nasm`.
+- 새 장비 setup 시 `cargo build --release` 가 nasm 없이 실패하면 위 메시지로 안내됨.


### PR DESCRIPTION
- `CLAUDE.md` — 새 세션에서 자동 로드되는 정적 컨텍스트. 프로젝트 개요·모듈 구조·시스템 요구사항(`nasm`)·개발 명령어·코드 컨벤션(한국어 출력 정책 포함)·커밋 컨벤션(Conventional Commits + 한국어 + `Co-authored-by` 트레일러)·향후 개선 후보·관련 문서 링크
- `MEMORY.md` — 시간에 따라 변하는 작업 컨텍스트. 최근 작업 로그(PR #5 일괄 변환), 결정 기록(`walkdir` 채택, `encode_to()` 분리, `convert_image_silent` 시그니처 변경, bin/lib 중복 컴파일 제거 이유), 진행 중/대기 항목(clap v4·`thiserror`·`rayon` 병렬화 등), 환경 메모(WSL `nasm` 의존성)
- 정적 컨벤션은 `CLAUDE.md`, 변하는 상태는 `MEMORY.md` 로 역할 분리하여 다른 장비/세션에서도 일관된 협업이 가능하도록