### PR TITLE
refactor: thiserror 기반 ConverterError 도입 — Box<dyn Error> 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ PNG/JPG/JPEG 이미지를 WebP/AVIF 로 변환하는 Rust CLI 도구.
 src/
 ├── main.rs            # CLI 진입점, 단일/일괄 분기
 ├── lib.rs             # 공개 API re-export (main.rs도 이 lib을 통해 import)
+├── error.rs           # ConverterError + Result 타입 (thiserror 기반)
 ├── converter.rs       # 단일 변환. encode_to() 헬퍼를 통해
 │                      # convert_image(UI 포함) / convert_image_silent(조용함) 가
 │                      # 동일 내부를 공유
@@ -65,8 +66,10 @@ cargo test test_batch                   # 일괄 변환 테스트만
   - CLI 출력과 README 예제에서 의미 있는 시각 단서로 사용 (`🚀 시작`, `✅ 성공`, `❌ 실패`, `📁 입력`, `💾 출력`)
   - 코드 주석/내부 로그에는 사용하지 않음
 - **에러 처리**
-  - 현재 `Result<T, Box<dyn std::error::Error>>` 사용
-  - 향후 `thiserror` 기반 커스텀 에러 타입으로 마이그레이션 예정
+  - `src/error.rs` 의 `ConverterError` enum (thiserror 기반) + `Result<T>` 별칭 사용
+  - 외부 크레이트 에러(io, image, dialoguer, ravif, ParseFloat) 는 `#[from]` 으로 자동 변환
+  - WebP 인코더의 `&str` 에러는 `to_string()` 으로 String 변환 후 `Webp(String)` variant
+  - 사용자 입력성 에러는 `UnsupportedFormat(String)`, `InvalidPath(String)` 등 명시적 variant — Display 메시지에 컨텍스트 포함
 - **테스트 출력**
   - `test_description!`, `test_step!`, `test_success!` 매크로로 가독성 있는 로그 (정의: `src/tests/test_utils.rs`)
   - 통합 테스트는 `tempfile` 로 격리
@@ -96,11 +99,10 @@ Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 (우선순위 추정 순)
 
-1. **커스텀 에러 타입** — `thiserror` 도입, `Box<dyn Error>` 제거
-2. **일괄 변환 병렬화** — `rayon` 으로 멀티코어 활용 (큰 폴더에서 효과 큼)
-3. **다양한 입력 확장자 회귀 테스트** — JPG/JPEG 명시 케이스 추가
-4. **대화형 모드 테스트** — 현재 미커버
-5. **다국어/메시지 분리** — 메시지를 별도 파일/리소스로
+1. **일괄 변환 병렬화** — `rayon` 으로 멀티코어 활용 (큰 폴더에서 효과 큼)
+2. **다양한 입력 확장자 회귀 테스트** — JPG/JPEG 명시 케이스 추가
+3. **대화형 모드 테스트** — 현재 미커버
+4. **다국어/메시지 분리** — 메시지를 별도 파일/리소스로
 
 ## 관련 문서
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,7 @@ dependencies = [
  "indicatif",
  "ravif",
  "tempfile",
+ "thiserror 1.0.69",
  "walkdir",
  "webp",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ dialoguer = "0.11"
 colored = "2.1"
 indicatif = "0.17"
 walkdir = "2.5"
+thiserror = "1.0"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,7 +12,19 @@
 
 ## 최근 작업 로그
 
-### 2026-04-30 — `refactor: clap v3 → v4 마이그레이션` (PR 진행 중)
+### 2026-04-30 — `refactor: thiserror 기반 ConverterError 도입` (PR 진행 중)
+
+- 신규 `src/error.rs` — `ConverterError` enum + `Result<T>` 별칭. variant: `Io` / `Image` / `Webp(String)` / `Avif` / `UnsupportedFormat(String)` / `InvalidPath(String)` / `Dialog` / `QualityParse`
+- 외부 크레이트 에러는 `#[from]` 으로 자동 변환 (`std::io::Error`, `image::ImageError`, `ravif::Error`, `dialoguer::Error`, `std::num::ParseFloatError`). webp 의 `&str` 에러만 수동 `to_string()` 매핑
+- `converter.rs` / `batch.rs` / `interactive.rs` 시그니처를 `Result<T, Box<dyn Error>>` → `Result<T>` 로 통일
+- `interactive.rs` 의 dialoguer `validate_with` 클로저는 `Result<(), &str>` 시그니처를 강제하므로, 이름 충돌 회피 위해 시그니처에 `crate::error::Result<()>` fully qualified 사용 (use 제거)
+- 에러 메시지가 컨텍스트를 포함하는 형태로 풍부해짐 (`"지원하지 않는 포맷입니다: xyz"`, `"입출력 오류: No such file or directory"` 등)
+- `test_invalid_format` 의 메시지 비교를 `assert_eq!` → `contains` 검증으로 갱신 (포맷명까지 검증 추가)
+- 12개 테스트 그대로 통과, 단일/배치/재귀 CLI 동작 회귀 없음
+- `Cargo.toml` 에 `thiserror = "1.0"` 추가
+- `CLAUDE.md` / `PROJECT_STRUCTURE.md` 갱신
+
+### 2026-04-30 — `refactor: clap v3 → v4 마이그레이션` (PR #7, merged)
 
 - `Cargo.toml` — `clap = "3.2.8"` → `clap = { version = "4.5", features = ["derive"] }`
 - `src/main.rs` — Builder 패턴(`App::new(...).arg(...)`)을 `#[derive(Parser)]` 구조체로 전면 재작성. 도움말은 doc 주석으로, `quality` 는 `f32` 자동 파싱(`.parse::<f32>().expect()` 제거), `interactive`/`recursive` 는 `bool` 자동 매핑
@@ -34,6 +46,9 @@
 
 ## 결정 기록
 
+- **`crate::error::Result` 를 1-generic alias 로 정의** — `pub type Result<T> = std::result::Result<T, ConverterError>`. 코드량은 줄지만 dialoguer 의 `validate_with` 클로저(`Result<(), &str>` 시그니처) 와 이름이 충돌함. interactive.rs 에서는 use 를 제거하고 시그니처에 `crate::error::Result<()>` fully qualified 사용으로 회피.
+- **WebP 에러는 `String` 으로 owned 변환** — `webp::Encoder::from_image` 가 `Result<Self, &str>` 를 반환. `&str` 은 `#[from]` 대상이 안 되고, `'static` 이 아니라 그대로 들고 있을 수도 없음. `Webp(String)` variant 로 받고 `.to_string()` 으로 매핑.
+- **`UnsupportedFormat` 에 포맷 문자열 포함** — 기존 `"지원하지 않는 포맷입니다"` 정적 메시지를 `"지원하지 않는 포맷입니다: {0}"` 로 변경. 디버그/사용자 경험 모두 향상되지만 기존 `assert_eq!` 테스트가 깨짐 → `contains` 검증으로 함께 갱신.
 - **clap v4 derive 매크로 채택** — 단순 builder 버전 업이 아니라 derive 로 전환. 코드 30% 감소, doc 주석이 자동으로 도움말이 됨, 타입 자동 파싱(특히 `quality: f32`). 변경 범위는 `main.rs` + `Cargo.toml` 로 한정되어 안전했음.
 - **`required_unless_present = "interactive"` 패턴 유지** — derive 에서도 동일한 의미. `Option<String>` + 비대화형 모드에서 `expect()` 로 추출. `ArgGroup` 도입은 과한 복잡도라 보류.
 - **`walkdir` 채택** — 재귀+필터 조합을 std `read_dir` 로만 처리하면 verbose 함. 비재귀에도 `WalkDir::new(path).max_depth(1)` 로 통일하여 코드 분기 단순화.
@@ -44,8 +59,8 @@
 ## 진행 중 / 대기
 
 - [x] **clap v4 마이그레이션** — 완료. derive 매크로로 전환.
-- [ ] **커스텀 에러 타입 (`thiserror`)** — 다음 PR 후보. `Box<dyn Error>` 제거, `converter`/`batch` 시그니처 갱신. 변경 범위는 중간.
-- [ ] **일괄 변환 병렬화 (`rayon`)** — 위 끝난 후. 진행률 바를 멀티스레드 친화적으로 바꾸는 작업이 같이 필요.
+- [x] **커스텀 에러 타입 (`thiserror`)** — 완료. `ConverterError` enum + 8 variant.
+- [ ] **일괄 변환 병렬화 (`rayon`)** — 다음 PR 후보. 진행률 바를 멀티스레드 친화적으로 바꾸는 작업이 같이 필요.
 - [ ] **JPG/JPEG 입력 명시 회귀 테스트** — 현재 PNG 만 명시 테스트. 작은 추가 작업.
 - [ ] **대화형 모드 테스트** — `dialoguer` 입력 모킹이 까다로워 우선순위 낮음.
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -12,6 +12,7 @@ image_converter/
 └── src/
     ├── main.rs             # 진입점 - CLI 인자 처리, 단일/일괄 분기
     ├── lib.rs              # 라이브러리 루트 - 공개 API re-export
+    ├── error.rs            # ConverterError + Result 타입 (thiserror 기반)
     ├── converter.rs        # 단일 파일 변환 + 인코딩 헬퍼
     ├── batch.rs            # 디렉토리 일괄 변환 (재귀 옵션)
     ├── interactive.rs      # 대화형 모드 (단일/디렉토리)
@@ -30,7 +31,15 @@ image_converter/
 - CLI 인자 파싱 (clap 사용)
 - 대화형/명령줄 모드 분기
 - 입력 경로 타입(파일/디렉토리)에 따라 단일/일괄 변환 분기
-- 에러 처리 및 종료
+- 에러 처리 및 종료 — `ConverterError` 의 `Display` 로 메시지 출력
+
+### `error.rs` (에러 타입)
+
+- `ConverterError` enum + `Result<T>` 별칭
+- thiserror 기반, 외부 크레이트 에러(io, image, dialoguer, ravif, ParseFloat) 는 `#[from]` 으로 자동 변환
+- WebP 인코더의 `&str` 에러는 별도 `Webp(String)` variant 로 매핑 (소유권 확보)
+- 사용자 입력성 에러는 `UnsupportedFormat`, `InvalidPath` 등 컨텍스트가 담긴 variant
+- Display 메시지는 모두 한국어 (`"입출력 오류: ..."`, `"지원하지 않는 포맷입니다: xyz"` 등)
 
 ### `converter.rs` (단일 변환 비즈니스 로직)
 
@@ -94,10 +103,8 @@ main.rs
 
 ## 향후 개선 제안
 
-1. **에러 타입 정의**: `Result<T, Box<dyn Error>>`를 커스텀 에러 타입으로 (`thiserror` 도입)
-2. **clap v4 마이그레이션**: 현재 v3.2.x 사용 중
-3. **병렬 일괄 변환**: `rayon`으로 배치 모드 멀티코어 활용
-4. **설정 모듈**: 품질 프리셋, 기본값 등을 관리하는 `config.rs`
-5. **다국어 지원**: 메시지를 별도 파일로 분리
+1. **병렬 일괄 변환**: `rayon`으로 배치 모드 멀티코어 활용
+2. **설정 모듈**: 품질 프리셋, 기본값 등을 관리하는 `config.rs`
+3. **다국어 지원**: 메시지를 별도 파일로 분리
 
 이 구조는 현재 프로젝트 규모에 적합하며, 향후 확장에도 대응할 수 있습니다.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 use crate::converter::convert_image_silent;
+use crate::error::{ConverterError, Result};
 use crate::utils::format_file_size;
 
 /// 디렉토리 변환 결과 합계
@@ -66,12 +67,15 @@ pub fn convert_directory(
     format: &str,
     quality: f32,
     recursive: bool,
-) -> Result<BatchSummary, Box<dyn std::error::Error>> {
+) -> Result<BatchSummary> {
     let input_path = Path::new(input_dir);
     let output_path = Path::new(output_dir);
 
     if !input_path.is_dir() {
-        return Err(format!("입력 경로가 디렉토리가 아닙니다: {}", input_dir).into());
+        return Err(ConverterError::InvalidPath(format!(
+            "입력 경로가 디렉토리가 아닙니다: {}",
+            input_dir
+        )));
     }
     std::fs::create_dir_all(output_path)?;
 
@@ -154,8 +158,10 @@ pub fn convert_directory(
         }
 
         match convert_image_silent(
-            file.to_str().ok_or("입력 경로 인코딩 오류")?,
-            dest.to_str().ok_or("출력 경로 인코딩 오류")?,
+            file.to_str()
+                .ok_or_else(|| ConverterError::InvalidPath(format!("{}", file.display())))?,
+            dest.to_str()
+                .ok_or_else(|| ConverterError::InvalidPath(format!("{}", dest.display())))?,
             format,
             quality,
         ) {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -5,6 +5,8 @@ use ravif::{Encoder as AvifEncoder, Img, RGBA8};
 use std::fs;
 use webp::Encoder as WebpEncoder;
 
+use crate::error::{ConverterError, Result};
+
 /// 단일 이미지 변환 결과 통계
 #[derive(Debug)]
 pub struct ConvertStats {
@@ -15,14 +17,11 @@ pub struct ConvertStats {
 }
 
 /// 메모리에 로드된 이미지를 지정한 포맷으로 인코딩
-fn encode_to(
-    img: &DynamicImage,
-    format: &str,
-    quality: f32,
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+fn encode_to(img: &DynamicImage, format: &str, quality: f32) -> Result<Vec<u8>> {
     match format {
         "webp" => {
-            let encoder = WebpEncoder::from_image(img)?;
+            let encoder = WebpEncoder::from_image(img)
+                .map_err(|e| ConverterError::Webp(e.to_string()))?;
             let data = encoder.encode(quality);
             Ok(data.to_vec())
         }
@@ -37,7 +36,7 @@ fn encode_to(
             let res = encoder.encode_rgba(Img::new(&pixels, width as usize, height as usize))?;
             Ok(res.avif_file)
         }
-        _ => Err("지원하지 않는 포맷입니다".into()),
+        _ => Err(ConverterError::UnsupportedFormat(format.to_string())),
     }
 }
 
@@ -47,7 +46,7 @@ pub fn convert_image_silent(
     output_path: &str,
     format: &str,
     quality: f32,
-) -> Result<ConvertStats, Box<dyn std::error::Error>> {
+) -> Result<ConvertStats> {
     let input_size = fs::metadata(input_path)?.len();
     let img = image::open(input_path)?;
     let (width, height) = img.dimensions();
@@ -68,7 +67,7 @@ pub fn convert_image(
     output_path: &str,
     format: &str,
     quality: f32,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<()> {
     println!("\n{} 이미지 변환을 시작합니다...", "🚀".bright_blue());
 
     let pb = ProgressBar::new(100);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,32 @@
+use thiserror::Error;
+
+/// 이미지 변환 과정에서 발생할 수 있는 모든 에러
+#[derive(Debug, Error)]
+pub enum ConverterError {
+    #[error("입출력 오류: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("이미지 디코딩 오류: {0}")]
+    Image(#[from] image::ImageError),
+
+    #[error("WebP 인코딩 오류: {0}")]
+    Webp(String),
+
+    #[error("AVIF 인코딩 오류: {0}")]
+    Avif(#[from] ravif::Error),
+
+    #[error("지원하지 않는 포맷입니다: {0}")]
+    UnsupportedFormat(String),
+
+    #[error("경로 오류: {0}")]
+    InvalidPath(String),
+
+    #[error("대화형 입력 오류: {0}")]
+    Dialog(#[from] dialoguer::Error),
+
+    #[error("품질 값 파싱 오류: {0}")]
+    QualityParse(#[from] std::num::ParseFloatError),
+}
+
+/// 라이브러리 전역에서 사용하는 Result 별칭
+pub type Result<T> = std::result::Result<T, ConverterError>;

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -6,7 +6,7 @@ use crate::batch::convert_directory;
 use crate::converter::convert_image;
 
 /// 대화형 모드로 이미지 변환
-pub fn interactive_mode() -> Result<(), Box<dyn std::error::Error>> {
+pub fn interactive_mode() -> crate::error::Result<()> {
     println!("{}", "🖼️  이미지 변환기 - 대화형 모드".bright_cyan().bold());
     println!("{}", "================================".bright_cyan());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,11 @@ mod tests;
 
 pub mod batch;
 pub mod converter;
+pub mod error;
 pub mod interactive;
 pub mod utils;
 
 pub use batch::{convert_directory, BatchSummary};
 pub use converter::{convert_image, convert_image_silent, ConvertStats};
+pub use error::{ConverterError, Result};
 pub use utils::format_file_size;

--- a/src/tests/integration_tests.rs
+++ b/src/tests/integration_tests.rs
@@ -146,9 +146,14 @@ fn test_invalid_format() {
     assert!(result.is_err(), "지원하지 않는 형식은 에러를 반환해야 함");
     test_success!("예상대로 에러 발생");
     
-    // 에러 메시지 확인
-    assert_eq!(result.unwrap_err().to_string(), "지원하지 않는 포맷입니다");
-    test_success!("올바른 에러 메시지 확인");
+    // 에러 메시지 확인 (포맷명까지 포함되어야 함)
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("지원하지 않는 포맷입니다") && err_msg.contains("xyz"),
+        "에러 메시지가 예상과 다름: {}",
+        err_msg
+    );
+    test_success!("올바른 에러 메시지 확인 ({})", err_msg);
 }
 
 #[test]


### PR DESCRIPTION
- 신규 `src/error.rs` — `ConverterError` enum + `Result<T>` 별칭. variants: `Io`, `Image`, `Webp(String)`, `Avif`, `UnsupportedFormat(String)`, `InvalidPath(String)`, `Dialog`, `QualityParse`. 모든 Display 메시지는 한국어
- 외부 크레이트 에러(`std::io::Error`, `image::ImageError`, `ravif::Error`, `dialoguer::Error`, `std::num::ParseFloatError`)는 `#[from]` 으로 자동 변환. webp 의 `&str` 에러만 수동 `to_string()` 매핑(`Webp(String)`)
- `converter.rs` / `batch.rs` / `interactive.rs` 시그니처를 `Result<T, Box<dyn Error>>` → `crate::error::Result<T>` 로 통일
- `interactive.rs` — dialoguer 의 `validate_with` 클로저가 `Result<(), &str>` 시그니처를 강제하므로 `Result` 이름 충돌 회피 위해 `use crate::error::Result` 제거하고 시그니처에 `crate::error::Result<()>` fully qualified 사용
- `batch.rs` — `format!("입력 경로가 디렉토리가 아닙니다: ...").into()` → `ConverterError::InvalidPath(...)`. OsStr 인코딩 실패 시 `&'static str` 대신 `InvalidPath` variant 로 디스플레이 가능한 경로 포함
- `converter.rs::encode_to` — `"지원하지 않는 포맷입니다"` 정적 메시지를 `UnsupportedFormat(format.to_string())` 로 바꿔 어떤 포맷이 들어왔는지 메시지에 포함 (`"지원하지 않는 포맷입니다: xyz"`)
- `lib.rs` — `pub mod error;` 등록, `ConverterError` / `Result` re-export
- `tests/integration_tests.rs::test_invalid_format` — 메시지 포맷 변경에 맞춰 `assert_eq!` → `contains` 검증으로 갱신, 포맷명까지 검증
- 12개 테스트 그대로 통과, 단일/배치/재귀 CLI 동작 회귀 없음. 에러 메시지는 컨텍스트가 더 풍부해짐 (예: `❌ 오류: 입출력 오류: No such file or directory (os error 2)`)
- `Cargo.toml` 에 `thiserror = "1.0"` 추가
- `CLAUDE.md` 에러 처리 섹션 / `PROJECT_STRUCTURE.md` 모듈 구조 / `MEMORY.md` 최근 작업·결정 기록·진행 항목 모두 갱신