### PR TITLE
perf: rayon 으로 일괄 변환 병렬화 — 8.3배 속도 향상 (16코어 / 8장 AVIF)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ src/
 ├── converter.rs       # 단일 변환. encode_to() 헬퍼를 통해
 │                      # convert_image(UI 포함) / convert_image_silent(조용함) 가
 │                      # 동일 내부를 공유
-├── batch.rs           # 디렉토리 일괄 변환 (walkdir 기반, 재귀 옵션, 구조 미러링)
+├── batch.rs           # 디렉토리 일괄 변환 (walkdir + rayon 병렬, 재귀 옵션, 구조 미러링)
 ├── interactive.rs     # 대화형 모드 (단일/디렉토리 선택 → 옵션 → 실행)
 ├── utils.rs           # format_file_size 등 헬퍼
 └── tests/             # 단위 + 통합 테스트 (총 12개)
@@ -99,10 +99,10 @@ Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 (우선순위 추정 순)
 
-1. **일괄 변환 병렬화** — `rayon` 으로 멀티코어 활용 (큰 폴더에서 효과 큼)
-2. **다양한 입력 확장자 회귀 테스트** — JPG/JPEG 명시 케이스 추가
-3. **대화형 모드 테스트** — 현재 미커버
-4. **다국어/메시지 분리** — 메시지를 별도 파일/리소스로
+1. **다양한 입력 확장자 회귀 테스트** — JPG/JPEG 명시 케이스 추가
+2. **대화형 모드 테스트** — 현재 미커버
+3. **다국어/메시지 분리** — 메시지를 별도 파일/리소스로
+4. **`--threads` CLI 옵션** — `RAYON_NUM_THREADS` 환경변수 외에 명시적 플래그
 
 ## 관련 문서
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "image",
  "indicatif",
  "ravif",
+ "rayon",
  "tempfile",
  "thiserror 1.0.69",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ colored = "2.1"
 indicatif = "0.17"
 walkdir = "2.5"
 thiserror = "1.0"
+rayon = "1.10"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,7 +12,21 @@
 
 ## 최근 작업 로그
 
-### 2026-04-30 — `refactor: thiserror 기반 ConverterError 도입` (PR 진행 중)
+### 2026-04-30 — `perf: rayon 으로 일괄 변환 병렬화` (PR 진행 중)
+
+- `Cargo.toml` — `rayon = "1.10"` 추가
+- `src/batch.rs` — 직렬 `for file in &files` 루프를 `files.par_iter().map(process_one).collect()` 패턴으로 전환. 각 파일 처리는 `process_one(file, in_dir, out_dir, fmt, q, &pb) -> Option<ConvertStats>` 헬퍼로 분리. 결과는 직렬 합산
+- 한 파일의 OsStr→str 인코딩 실패 시 기존엔 `?` 로 outer 함수가 통째로 실패했지만, 이제 그 파일만 실패 처리하고 나머지는 그대로 진행 (병렬 의미상 더 정확)
+- ProgressBar 와 `pb.println` 은 indicatif 내부 Mutex 로 thread-safe — 별도 락 없이 그대로 공유
+- 진행률 메시지(`pb.set_message`)는 race 가 noisy 해서 제거. 진행률 카운트 + 마지막 finish 메시지만 표시
+- **성능**: 16코어 환경에서 800x800 노이즈 PNG 8장 → AVIF q80 변환 비교
+  - 직렬 (`RAYON_NUM_THREADS=1`): **28.87s**
+  - 병렬 (default=16): **3.48s** (≈ **8.3배** 속도 향상, 8개 파일 / 거의 이론적 최대치에 근접)
+- 12개 테스트 그대로 통과, 단일 변환과 빈 디렉토리 처리 회귀 없음
+- 사용자가 스레드 수 조절 시 `RAYON_NUM_THREADS` 환경변수 사용 (별도 CLI 플래그는 향후 후보)
+- README/CLAUDE.md/PROJECT_STRUCTURE.md 갱신
+
+### 2026-04-30 — `refactor: thiserror 기반 ConverterError 도입` (PR #8, merged)
 
 - 신규 `src/error.rs` — `ConverterError` enum + `Result<T>` 별칭. variant: `Io` / `Image` / `Webp(String)` / `Avif` / `UnsupportedFormat(String)` / `InvalidPath(String)` / `Dialog` / `QualityParse`
 - 외부 크레이트 에러는 `#[from]` 으로 자동 변환 (`std::io::Error`, `image::ImageError`, `ravif::Error`, `dialoguer::Error`, `std::num::ParseFloatError`). webp 의 `&str` 에러만 수동 `to_string()` 매핑
@@ -46,6 +60,10 @@
 
 ## 결정 기록
 
+- **rayon `par_iter().map().collect()` + 직렬 합산** — Atomic 카운터나 `fold/reduce` 보다 단순. `BatchSummary` 구조체 변경 없이 결과만 병렬 수집 후 한 번에 누적.
+- **rayon 도입 이후 path 인코딩 실패의 의미 변경** — 직렬 시절엔 `?` 로 outer 함수까지 propagation 되어 한 파일이 실패하면 전체 일괄 변환이 중단됐는데, 병렬화하면서 "그 파일만 실패" 패턴으로 변경. 일괄 변환의 자연스러운 의미와 더 잘 맞음.
+- **진행률 메시지 제거** — `pb.set_message(file_name)` 은 병렬에서 race 로 깜빡깜빡거려 정보보다 noise. 카운트(`{pos}/{len}`)만 보여주고 finish 메시지로 마무리.
+- **스레드 수는 환경변수로** — `RAYON_NUM_THREADS=N` 으로 제어. 명시적 `--threads` CLI 플래그는 단순함을 위해 보류, 필요해지면 추가.
 - **`crate::error::Result` 를 1-generic alias 로 정의** — `pub type Result<T> = std::result::Result<T, ConverterError>`. 코드량은 줄지만 dialoguer 의 `validate_with` 클로저(`Result<(), &str>` 시그니처) 와 이름이 충돌함. interactive.rs 에서는 use 를 제거하고 시그니처에 `crate::error::Result<()>` fully qualified 사용으로 회피.
 - **WebP 에러는 `String` 으로 owned 변환** — `webp::Encoder::from_image` 가 `Result<Self, &str>` 를 반환. `&str` 은 `#[from]` 대상이 안 되고, `'static` 이 아니라 그대로 들고 있을 수도 없음. `Webp(String)` variant 로 받고 `.to_string()` 으로 매핑.
 - **`UnsupportedFormat` 에 포맷 문자열 포함** — 기존 `"지원하지 않는 포맷입니다"` 정적 메시지를 `"지원하지 않는 포맷입니다: {0}"` 로 변경. 디버그/사용자 경험 모두 향상되지만 기존 `assert_eq!` 테스트가 깨짐 → `contains` 검증으로 함께 갱신.
@@ -60,9 +78,10 @@
 
 - [x] **clap v4 마이그레이션** — 완료. derive 매크로로 전환.
 - [x] **커스텀 에러 타입 (`thiserror`)** — 완료. `ConverterError` enum + 8 variant.
-- [ ] **일괄 변환 병렬화 (`rayon`)** — 다음 PR 후보. 진행률 바를 멀티스레드 친화적으로 바꾸는 작업이 같이 필요.
+- [x] **일괄 변환 병렬화 (`rayon`)** — 완료. 16코어에서 8장 AVIF 변환 8.3배 ↑.
 - [ ] **JPG/JPEG 입력 명시 회귀 테스트** — 현재 PNG 만 명시 테스트. 작은 추가 작업.
 - [ ] **대화형 모드 테스트** — `dialoguer` 입력 모킹이 까다로워 우선순위 낮음.
+- [ ] **`--threads` CLI 옵션** — 현재는 `RAYON_NUM_THREADS` 환경변수만. 작은 추가 작업.
 
 ## 환경 메모
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -50,9 +50,12 @@ image_converter/
 
 ### `batch.rs` (디렉토리 일괄 변환)
 
-- `convert_directory`: 입력 디렉토리에서 PNG/JPG/JPEG 만 골라 일괄 변환
+- `convert_directory`: 입력 디렉토리에서 PNG/JPG/JPEG 만 골라 **rayon 으로 병렬** 변환
+- 각 파일은 `process_one` 헬퍼가 처리하고 `Option<ConvertStats>` 를 반환 — 한 파일이 실패해도 나머지는 그대로 진행
+- 결과는 직렬 합산하여 `BatchSummary` 통계로 반환
+- 진행률 바 (`indicatif::ProgressBar`) 와 `pb.println` 은 thread-safe (내부 Mutex)
 - 재귀 모드에서 입력 디렉토리 구조를 출력에 미러링
-- 전체 진행률 표시 + 합계 통계 (`BatchSummary`) 반환
+- 스레드 수는 `RAYON_NUM_THREADS` 환경변수로 조절 (기본: CPU 코어 수)
 
 ### `interactive.rs` (사용자 인터페이스)
 
@@ -103,7 +106,7 @@ main.rs
 
 ## 향후 개선 제안
 
-1. **병렬 일괄 변환**: `rayon`으로 배치 모드 멀티코어 활용
+1. **`--threads` CLI 옵션**: 환경변수 외에 명시적 플래그
 2. **설정 모듈**: 품질 프리셋, 기본값 등을 관리하는 `config.rs`
 3. **다국어 지원**: 메시지를 별도 파일로 분리
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PNG, JPG, JPEG 이미지를 WebP와 AVIF 형식으로 변환하는 고성능 이
 ## ✨ 주요 기능
 
 - **다양한 형식 지원**: PNG, JPG, JPEG → WebP, AVIF
-- **단일 파일 + 디렉토리 일괄 변환**: 입력이 디렉토리이면 자동으로 일괄 모드
+- **단일 파일 + 디렉토리 일괄 변환**: 입력이 디렉토리이면 자동으로 일괄 모드 (rayon 으로 멀티코어 병렬 처리)
 - **재귀 변환**: `--recursive` 옵션으로 하위 폴더까지 한 번에 변환 (구조 그대로 미러링)
 - **대화형 모드**: 단일/디렉토리 모드를 단계별로 안내
 - **용량 비교**: 변환 전후 파일 크기 및 감소율 표시 (배치 모드는 합계까지)
@@ -62,7 +62,7 @@ cargo build --release
 
 ### 명령줄 모드 - 디렉토리 일괄 변환
 
-입력 경로가 디렉토리이면 자동으로 일괄 변환 모드로 동작합니다.
+입력 경로가 디렉토리이면 자동으로 일괄 변환 모드로 동작합니다. 변환은 **rayon** 을 통해 멀티코어로 병렬 처리됩니다 (큰 폴더에서 큰 속도 향상).
 
 ```bash
 # photos/ 안의 모든 PNG/JPG/JPEG 를 WebP로 변환 (현재 폴더만)
@@ -70,6 +70,9 @@ cargo build --release
 
 # 하위 폴더까지 재귀적으로 변환 (입력 디렉토리 구조 그대로 미러링)
 ./target/release/image_converter -i photos -o photos_webp -f webp -q 80 -r
+
+# 사용할 스레드 수 제한 (기본: CPU 코어 수)
+RAYON_NUM_THREADS=4 ./target/release/image_converter -i photos -o photos_webp -f webp -r
 ```
 
 ## 📊 옵션
@@ -141,6 +144,8 @@ imgconvi
 - **colored**: 색상 출력
 - **indicatif**: 진행률 표시
 - **walkdir**: 디렉토리 재귀 순회
+- **rayon**: 일괄 변환 멀티코어 병렬 처리
+- **thiserror**: 명시적 커스텀 에러 타입
 
 ## 📈 성능
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,9 +1,10 @@
 use colored::*;
 use indicatif::{ProgressBar, ProgressStyle};
+use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
-use crate::converter::convert_image_silent;
+use crate::converter::{convert_image_silent, ConvertStats};
 use crate::error::{ConverterError, Result};
 use crate::utils::format_file_size;
 
@@ -134,58 +135,92 @@ pub fn convert_directory(
         total_output_size: 0,
     };
 
-    for file in &files {
-        let display = file
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("?")
-            .to_string();
-        pb.set_message(display.clone());
+    // 병렬 변환 — ProgressBar/println 은 indicatif 내부 Mutex 로 thread-safe
+    let outcomes: Vec<Option<ConvertStats>> = files
+        .par_iter()
+        .map(|file| process_one(file, input_path, output_path, format, quality, &pb))
+        .collect();
 
-        let dest = map_output_path(file, input_path, output_path, format);
-        if let Some(parent) = dest.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                pb.println(format!(
-                    "  {} {}: 출력 디렉토리 생성 실패 ({})",
-                    "❌".bright_red(),
-                    display,
-                    e
-                ));
-                summary.failed += 1;
-                pb.inc(1);
-                continue;
-            }
-        }
-
-        match convert_image_silent(
-            file.to_str()
-                .ok_or_else(|| ConverterError::InvalidPath(format!("{}", file.display())))?,
-            dest.to_str()
-                .ok_or_else(|| ConverterError::InvalidPath(format!("{}", dest.display())))?,
-            format,
-            quality,
-        ) {
-            Ok(stats) => {
+    // 결과 직렬 합산
+    for outcome in outcomes {
+        match outcome {
+            Some(stats) => {
                 summary.succeeded += 1;
                 summary.total_input_size += stats.input_size;
                 summary.total_output_size += stats.output_size;
             }
-            Err(e) => {
-                summary.failed += 1;
-                pb.println(format!(
-                    "  {} {}: {}",
-                    "❌".bright_red(),
-                    display,
-                    e
-                ));
-            }
+            None => summary.failed += 1,
         }
-        pb.inc(1);
     }
 
     pb.finish_with_message("✅ 일괄 변환 완료!");
     print_batch_summary(&summary, quality);
     Ok(summary)
+}
+
+/// 단일 파일을 변환하고, 진행률 바를 1 증가시킨다. 실패 시 progressbar 위에 메시지를 찍고 None 반환
+fn process_one(
+    file: &Path,
+    input_dir: &Path,
+    output_dir: &Path,
+    format: &str,
+    quality: f32,
+    pb: &ProgressBar,
+) -> Option<ConvertStats> {
+    let display = file
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("?")
+        .to_string();
+
+    let dest = map_output_path(file, input_dir, output_dir, format);
+    if let Some(parent) = dest.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            pb.println(format!(
+                "  {} {}: 출력 디렉토리 생성 실패 ({})",
+                "❌".bright_red(),
+                display,
+                e
+            ));
+            pb.inc(1);
+            return None;
+        }
+    }
+
+    let in_str = match file.to_str() {
+        Some(s) => s,
+        None => {
+            pb.println(format!(
+                "  {} {}: 입력 경로 인코딩 오류",
+                "❌".bright_red(),
+                display
+            ));
+            pb.inc(1);
+            return None;
+        }
+    };
+    let out_str = match dest.to_str() {
+        Some(s) => s,
+        None => {
+            pb.println(format!(
+                "  {} {}: 출력 경로 인코딩 오류",
+                "❌".bright_red(),
+                display
+            ));
+            pb.inc(1);
+            return None;
+        }
+    };
+
+    let result = match convert_image_silent(in_str, out_str, format, quality) {
+        Ok(stats) => Some(stats),
+        Err(e) => {
+            pb.println(format!("  {} {}: {}", "❌".bright_red(), display, e));
+            None
+        }
+    };
+    pb.inc(1);
+    result
 }
 
 fn print_batch_summary(summary: &BatchSummary, quality: f32) {


### PR DESCRIPTION
- `Cargo.toml` — `rayon = "1.10"` 추가
- `src/batch.rs` — 직렬 `for file in &files` 루프를 `files.par_iter().map(process_one).collect()` 패턴으로 전환. 각 파일 처리는 `process_one(file, in_dir, out_dir, fmt, q, &pb) -> Option<ConvertStats>` 헬퍼로 분리. 결과는 직렬 합산하여 `BatchSummary` 구조체 변경 없음
- 한 파일의 OsStr→str 인코딩 실패 시 기존엔 `?` 로 outer 함수가 통째로 실패했지만, 이제 그 파일만 실패 처리하고 나머지는 그대로 진행 (병렬의 자연스러운 의미와 일치)
- `indicatif::ProgressBar` 와 `pb.println` 은 내부 Mutex 로 thread-safe — 별도 락 없이 그대로 공유. `pb.set_message(file_name)` 은 병렬에서 race 가 noisy 해서 제거하고 카운트(`{pos}/{len}`) + finish 메시지만 표시
- 스레드 수는 `RAYON_NUM_THREADS` 환경변수로 조절 (기본: CPU 코어 수). 명시적 `--threads` CLI 플래그는 단순함을 위해 보류, 향후 추가 가능

성능 측정 (16코어 WSL2, 800x800 노이즈 PNG 8장 → AVIF q80):

| 모드 | 시간 |
|---|---|
| 직렬 (`RAYON_NUM_THREADS=1`) | 28.87s |
| 병렬 (default=16) | 3.48s — **약 8.3배 ↑** |

회귀 검증:
- 12개 테스트 그대로 통과
- 단일 파일 변환, 빈 디렉토리 처리, 비이미지 스킵 모두 회귀 없음

문서 갱신:
- `README.md` — 일괄 모드 설명에 병렬 처리 안내 + `RAYON_NUM_THREADS` 사용 예제, 기술 스택에 rayon/thiserror 추가
- `CLAUDE.md` — 모듈 설명 갱신, 향후 후보 정리 (`--threads` 추가)
- `PROJECT_STRUCTURE.md` — `batch.rs` 책임 갱신 (`process_one` 헬퍼, thread-safe 메모, 환경변수)
- `MEMORY.md` — 작업 로그/결정 기록/진행 항목 갱신