### PR TITLE
feat: 다중 입출력 포맷 지원 — PNG/JPEG 출력 + WebP/TIFF/BMP/ICO 입력

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,16 @@
 # Image Converter
 
-PNG/JPG/JPEG 이미지를 WebP/AVIF 로 변환하는 Rust CLI 도구.
+여러 이미지 포맷 (PNG/JPG/JPEG/WebP/TIFF/BMP/ICO) 을 PNG/JPG/WebP/AVIF 로 양방향 변환하는 Rust CLI 도구.
 
 ## 프로젝트 개요
 
 - **언어/도구**: Rust (edition 2021)
-- **지원**: 단일 파일 변환 + 디렉토리 일괄 변환 (재귀 옵션)
+- **지원 입력**: PNG, JPG, JPEG, WebP, TIFF, BMP, ICO (`image` 크레이트 default features)
+- **지원 출력**: PNG, JPG/JPEG, WebP, AVIF
+- **AVIF 입력은 미지원** — `libdav1d` 시스템 의존성을 요구해서 별도 PR 후보
+- **모드**: 단일 파일 변환 + 디렉토리 일괄 변환 (재귀 옵션)
 - **인터페이스**: 명령줄 모드 (`-i/-o/-f/-q/-r`) + 대화형 모드 (`-I`)
-- **변환 엔진**: WebP는 `webp` 크레이트, AVIF는 `ravif` (rav1e 기반)
+- **변환 엔진**: WebP 인코딩은 `webp` 크레이트, AVIF 인코딩은 `ravif` (rav1e 기반), 그 외 PNG/JPEG/TIFF/BMP/ICO 디코딩과 PNG/JPEG 인코딩은 `image` 크레이트
 
 세부 사용법은 `README.md` 참고.
 
@@ -18,13 +21,15 @@ src/
 ├── main.rs            # CLI 진입점, 단일/일괄 분기
 ├── lib.rs             # 공개 API re-export (main.rs도 이 lib을 통해 import)
 ├── error.rs           # ConverterError + Result 타입 (thiserror 기반)
-├── converter.rs       # 단일 변환. encode_to() 헬퍼를 통해
-│                      # convert_image(UI 포함) / convert_image_silent(조용함) 가
-│                      # 동일 내부를 공유
-├── batch.rs           # 디렉토리 일괄 변환 (walkdir + rayon 병렬, 재귀 옵션, 구조 미러링)
-├── interactive.rs     # 대화형 모드 (단일/디렉토리 선택 → 옵션 → 실행)
+├── converter.rs       # 단일 변환. encode_to() 가 webp/avif/png/jpg|jpeg 분기를
+│                      # 처리하고, convert_image(UI 포함) / convert_image_silent
+│                      # (조용함) 가 동일 내부를 공유
+├── batch.rs           # 디렉토리 일괄 변환 (walkdir + rayon 병렬, 재귀 옵션, 구조 미러링).
+│                      # 입력 화이트리스트: png/jpg/jpeg/webp/tiff/tif/bmp/ico
+├── interactive.rs     # 대화형 모드 (단일/디렉토리 선택 → 출력 포맷 → 옵션 → 실행).
+│                      # PNG 출력 시 quality 단계는 자동 스킵
 ├── utils.rs           # format_file_size 등 헬퍼
-└── tests/             # 단위 + 통합 테스트 (총 12개)
+└── tests/             # 단위 + 통합 테스트 (총 18개)
 ```
 
 세부 책임은 `PROJECT_STRUCTURE.md` 참고.
@@ -99,10 +104,12 @@ Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 (우선순위 추정 순)
 
-1. **다양한 입력 확장자 회귀 테스트** — JPG/JPEG 명시 케이스 추가
-2. **대화형 모드 테스트** — 현재 미커버
-3. **다국어/메시지 분리** — 메시지를 별도 파일/리소스로
-4. **`--threads` CLI 옵션** — `RAYON_NUM_THREADS` 환경변수 외에 명시적 플래그
+1. **AVIF 입력 지원** — `image` 크레이트의 `avif-decoder` feature 활성화 + `libdav1d-dev` (apt) / `dav1d` (brew) 시스템 의존성 추가. `is_supported_image()` 화이트리스트에 `"avif"` 한 단어 추가하면 됨
+2. **`--threads` CLI 옵션** — `RAYON_NUM_THREADS` 환경변수 외에 명시적 플래그
+3. **JPG/JPEG 단일 입력 회귀 테스트** — 현재는 혼합 배치 / 다른 포맷 출력으로만 간접 커버. 명시적 단일 케이스
+4. **HEIC 입력** — iPhone 사진 변환용. `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트 도입 필요
+5. **대화형 모드 테스트** — 현재 미커버
+6. **다국어/메시지 분리** — 메시지를 별도 파일/리소스로
 
 ## 관련 문서
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,9 +12,28 @@
 
 ## 최근 작업 로그
 
-### 2026-04-30 — `perf: rayon 으로 일괄 변환 병렬화` (PR 진행 중)
+### 2026-04-30 — `feat: 다중 입출력 포맷 지원 (역변환 + 추가 입력)` (PR 진행 중)
+
+- `Cargo.toml` **변경 없음** — 모든 신규 포맷이 `image` 0.24.9 의 default features 로 이미 가능
+- `src/converter.rs` `encode_to()` — 기존 `webp`/`avif` 분기에 `png`, `jpg|jpeg` 추가
+  - **PNG**: `image::ImageOutputFormat::Png` + `Cursor` 로 무손실 인코딩. `quality` 인자는 조용히 무시
+  - **JPEG**: 알파 채널 미지원이라 `to_rgb8()` 로 RGB 다운샘플 후 `ImageOutputFormat::Jpeg(quality.clamp(1, 100) as u8)`. `jpg`/`jpeg` 둘 다 같은 분기로 처리
+- `src/batch.rs` `is_supported_image()` — 입력 화이트리스트에 `webp`, `tiff`, `tif`, `bmp`, `ico` 추가. AVIF 는 의도적으로 제외 (별도 PR)
+- `src/interactive.rs` — 출력 포맷 선택지에 PNG/JPEG 추가. PNG 선택 시 quality 단계 자동 스킵 + "무손실이라 적용 안 됨" 한 줄 안내 출력
+- `src/main.rs` — doc 주석 / `-f` value 설명 / `-q` 설명에 PNG 무손실 안내 / 버전 `2.2` → `2.3`
+- 통합 테스트 6개 추가 (총 12 → 18, 모두 통과):
+  - `test_png_output_from_webp_input` — WebP → PNG 역변환 + PNG 시그니처 검증
+  - `test_jpeg_output_from_png_input` — PNG → JPEG + JPEG 시그니처 검증
+  - `test_jpg_alias_for_jpeg` — `jpg` 가 `jpeg` 와 동일 분기인지 확인
+  - `test_tiff_input_to_webp` — TIFF 입력 디코딩
+  - `test_bmp_input_to_jpeg` — BMP 입력 디코딩
+  - `test_batch_mixed_input_formats` — PNG + WebP + TIFF + BMP 4종이 한 디렉토리에 섞인 일괄 변환 (모두 PNG 로 통합 출력)
+- README/CLAUDE/PROJECT_STRUCTURE 갱신 — 지원 포맷 매트릭스 표 추가
+
+### 2026-04-30 — `perf: rayon 으로 일괄 변환 병렬화` (PR #9, merged)
 
 - `Cargo.toml` — `rayon = "1.10"` 추가
+
 - `src/batch.rs` — 직렬 `for file in &files` 루프를 `files.par_iter().map(process_one).collect()` 패턴으로 전환. 각 파일 처리는 `process_one(file, in_dir, out_dir, fmt, q, &pb) -> Option<ConvertStats>` 헬퍼로 분리. 결과는 직렬 합산
 - 한 파일의 OsStr→str 인코딩 실패 시 기존엔 `?` 로 outer 함수가 통째로 실패했지만, 이제 그 파일만 실패 처리하고 나머지는 그대로 진행 (병렬 의미상 더 정확)
 - ProgressBar 와 `pb.println` 은 indicatif 내부 Mutex 로 thread-safe — 별도 락 없이 그대로 공유
@@ -60,6 +79,11 @@
 
 ## 결정 기록
 
+- **A안 채택 (AVIF 입력 제외)** — `image` 크레이트의 `avif-decoder` feature 는 `dav1d` 시스템 라이브러리 (`libdav1d-dev` apt / `dav1d` brew) 를 요구. 현재 `nasm` 한 가지만 시스템 의존성으로 잡혀 있는 깔끔함을 유지하기 위해 1단계에서 AVIF 입력만 제외. WebP 디코딩은 `image` 0.24 default features 에 포함되어 Cargo.toml 변경 없이 동작.
+- **PNG quality 는 조용히 무시** — `encode_to("png", ...)` 가 quality 인자를 받지만 사용하지 않음. CLI 와 대화형 모드에서 사용자에게 "무손실이라 적용 안 됨" 한 줄 안내 + `-q` doc 주석에도 명시. 에러로 거부하지 않는 이유는 배치 모드에서 한 quality 값을 여러 출력 포맷에 공통 적용하는 흐름을 깨지 않기 위함.
+- **JPEG 출력 시 `to_rgb8()` 로 명시적 RGB 다운샘플** — `image` 의 `write_to(..., ImageOutputFormat::Jpeg(q))` 는 RGBA 입력도 받지만 동작이 버전에 따라 다를 수 있음. 명시적으로 `DynamicImage::ImageRgb8(img.to_rgb8())` 로 변환 후 인코딩하여 알파 채널 처리를 확정적으로 만듦. 알파 픽셀은 검정 배경 위에 합성된 형태로 처리됨 (image 크레이트 기본 동작).
+- **`jpg` 와 `jpeg` 를 같은 분기로** — `match` 의 or-pattern (`"jpg" | "jpeg"`) 으로 한 분기에서 처리. 사용자 친화적이면서 코드 중복 없음. 출력 확장자도 사용자가 명시한 그대로 사용 (둘 다 동일 JPEG 컨테이너).
+- **WebP 픽스처는 webp 크레이트로 생성** — `image::ImageBuffer::save("path.webp")` 는 `image` 의 `webp-encoder` feature (`libwebp` 의존) 가 필요해서 사용 못 함. 테스트에서는 PNG 시드를 만든 후 `convert_image_silent(seed.png, fixture.webp, "webp", ...)` 로 우회.
 - **rayon `par_iter().map().collect()` + 직렬 합산** — Atomic 카운터나 `fold/reduce` 보다 단순. `BatchSummary` 구조체 변경 없이 결과만 병렬 수집 후 한 번에 누적.
 - **rayon 도입 이후 path 인코딩 실패의 의미 변경** — 직렬 시절엔 `?` 로 outer 함수까지 propagation 되어 한 파일이 실패하면 전체 일괄 변환이 중단됐는데, 병렬화하면서 "그 파일만 실패" 패턴으로 변경. 일괄 변환의 자연스러운 의미와 더 잘 맞음.
 - **진행률 메시지 제거** — `pb.set_message(file_name)` 은 병렬에서 race 로 깜빡깜빡거려 정보보다 noise. 카운트(`{pos}/{len}`)만 보여주고 finish 메시지로 마무리.
@@ -79,9 +103,12 @@
 - [x] **clap v4 마이그레이션** — 완료. derive 매크로로 전환.
 - [x] **커스텀 에러 타입 (`thiserror`)** — 완료. `ConverterError` enum + 8 variant.
 - [x] **일괄 변환 병렬화 (`rayon`)** — 완료. 16코어에서 8장 AVIF 변환 8.3배 ↑.
-- [ ] **JPG/JPEG 입력 명시 회귀 테스트** — 현재 PNG 만 명시 테스트. 작은 추가 작업.
-- [ ] **대화형 모드 테스트** — `dialoguer` 입력 모킹이 까다로워 우선순위 낮음.
+- [x] **다중 입출력 포맷 지원 (A안)** — 완료. PNG/JPG/JPEG 출력 + WebP/TIFF/BMP/ICO 입력 추가. 18 테스트 통과.
+- [ ] **AVIF 입력 (B안 후속 PR)** — `Cargo.toml` 에 `image = { ..., features = ["avif-decoder"] }` + `is_supported_image()` 화이트리스트에 `"avif"` 한 단어 + `libdav1d` 시스템 의존성 안내. 매우 작은 PR.
 - [ ] **`--threads` CLI 옵션** — 현재는 `RAYON_NUM_THREADS` 환경변수만. 작은 추가 작업.
+- [ ] **JPG/JPEG 단일 입력 명시 회귀 테스트** — 다중 포맷 PR 에서 혼합 배치로 간접 커버. 명시적 단일 케이스는 별도.
+- [ ] **HEIC 입력** — `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트. 부담 큼.
+- [ ] **대화형 모드 테스트** — `dialoguer` 입력 모킹이 까다로워 우선순위 낮음.
 
 ## 환경 메모
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -43,14 +43,20 @@ image_converter/
 
 ### `converter.rs` (단일 변환 비즈니스 로직)
 
-- `encode_to`: 메모리 이미지를 WebP/AVIF 바이트로 인코딩 (내부 헬퍼)
+- `encode_to`: 메모리 이미지를 WebP/AVIF/PNG/JPG/JPEG 바이트로 인코딩 (내부 헬퍼)
+  - WebP: `webp::Encoder::from_image` + `encode(quality)`
+  - AVIF: `ravif::Encoder` (rav1e 기반, RGBA 추출 후 인코딩)
+  - PNG: `image` 크레이트의 `write_to(&mut Cursor, ImageOutputFormat::Png)` — 무손실, quality 무시
+  - JPG/JPEG: 알파 채널을 가질 수 없어 `to_rgb8()` 으로 다운샘플 후 `ImageOutputFormat::Jpeg(quality_u8)`
 - `convert_image`: 진행률 + 결과 출력 포함
 - `convert_image_silent`: 출력 없는 변환 (`ConvertStats` 반환). 배치 모드와 테스트에서 사용
 - 두 함수 모두 동일한 내부 인코딩 헬퍼를 호출 (코드 중복 제거)
 
 ### `batch.rs` (디렉토리 일괄 변환)
 
-- `convert_directory`: 입력 디렉토리에서 PNG/JPG/JPEG 만 골라 **rayon 으로 병렬** 변환
+- `convert_directory`: 입력 디렉토리에서 지원 포맷만 골라 **rayon 으로 병렬** 변환
+  - 입력 화이트리스트: `png`/`jpg`/`jpeg`/`webp`/`tiff`/`tif`/`bmp`/`ico`
+  - AVIF 는 디코더가 `libdav1d` 시스템 의존성을 요구해서 입력 화이트리스트에서 제외 (별도 PR 후보)
 - 각 파일은 `process_one` 헬퍼가 처리하고 `Option<ConvertStats>` 를 반환 — 한 파일이 실패해도 나머지는 그대로 진행
 - 결과는 직렬 합산하여 `BatchSummary` 통계로 반환
 - 진행률 바 (`indicatif::ProgressBar`) 와 `pb.println` 은 thread-safe (내부 Mutex)
@@ -62,6 +68,8 @@ image_converter/
 - 대화형 모드 구현
 - 단일 파일 / 디렉토리 모드 선택
 - 디렉토리 모드에서 재귀 옵션 질문
+- 출력 포맷 선택지: WebP / AVIF / PNG / JPEG
+- PNG 출력 선택 시 quality 단계는 자동으로 스킵 (무손실 포맷이라 의미 없음)
 - 단계별 사용자 입력 처리
 
 ### `utils.rs` (공통 유틸리티)
@@ -106,8 +114,10 @@ main.rs
 
 ## 향후 개선 제안
 
-1. **`--threads` CLI 옵션**: 환경변수 외에 명시적 플래그
-2. **설정 모듈**: 품질 프리셋, 기본값 등을 관리하는 `config.rs`
-3. **다국어 지원**: 메시지를 별도 파일로 분리
+1. **AVIF 입력 지원**: `image` 크레이트의 `avif-decoder` feature 활성화 + `libdav1d` 시스템 의존성 추가
+2. **`--threads` CLI 옵션**: 환경변수 외에 명시적 플래그
+3. **HEIC 입력**: iPhone 사진 변환용. `libheif` 시스템 의존성 + 외부 크레이트
+4. **설정 모듈**: 품질 프리셋, 기본값 등을 관리하는 `config.rs`
+5. **다국어 지원**: 메시지를 별도 파일로 분리
 
 이 구조는 현재 프로젝트 규모에 적합하며, 향후 확장에도 대응할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
 # 🖼️ Image Converter
 
-PNG, JPG, JPEG 이미지를 WebP와 AVIF 형식으로 변환하는 고성능 이미지 변환기입니다.
+여러 이미지 포맷을 양방향으로 변환하는 고성능 Rust CLI 도구. WebP/AVIF 압축뿐 아니라 PNG/JPEG 로의 역변환도 지원합니다.
 
 ## ✨ 주요 기능
 
-- **다양한 형식 지원**: PNG, JPG, JPEG → WebP, AVIF
+- **양방향 포맷 변환**: PNG/JPG/JPEG/WebP/TIFF/BMP/ICO → PNG/JPG/WebP/AVIF
 - **단일 파일 + 디렉토리 일괄 변환**: 입력이 디렉토리이면 자동으로 일괄 모드 (rayon 으로 멀티코어 병렬 처리)
 - **재귀 변환**: `--recursive` 옵션으로 하위 폴더까지 한 번에 변환 (구조 그대로 미러링)
 - **대화형 모드**: 단일/디렉토리 모드를 단계별로 안내
 - **용량 비교**: 변환 전후 파일 크기 및 감소율 표시 (배치 모드는 합계까지)
 - **진행 상황 표시**: 실시간 진행률 표시
-- **품질 설정**: 1-100% 품질 조정 가능
+- **품질 설정**: 1-100% 품질 조정 가능 (PNG 는 무손실이라 자동 무시)
 - **아름다운 UI**: 이모티콘과 색상으로 보기 좋은 출력
+
+## 🎯 지원 포맷 매트릭스
+
+| 포맷       | 입력 | 출력 | 비고                                                             |
+| ---------- | :--: | :--: | ---------------------------------------------------------------- |
+| PNG        |  ✅  |  ✅  | 무손실. 출력 시 `--quality` 무시                                 |
+| JPG / JPEG |  ✅  |  ✅  | 알파 채널 미지원 — 자동으로 RGB 변환 후 인코딩                   |
+| WebP       |  ✅  |  ✅  |                                                                  |
+| AVIF       |  ❌  |  ✅  | 입력은 `libdav1d` 시스템 의존성을 요구하므로 추후 별도 PR 로 추가 |
+| TIFF       |  ✅  |  ❌  | 입력만 지원                                                      |
+| BMP        |  ✅  |  ❌  | 입력만 지원                                                      |
+| ICO        |  ✅  |  ❌  | 입력만 지원                                                      |
 
 ## 📦 설치
 
@@ -58,6 +70,15 @@ cargo build --release
 
 # AVIF로 변환 (품질 80%)
 ./target/release/image_converter -i photo.jpg -o photo.avif -f avif -q 80
+
+# 역변환: WebP → PNG (무손실, quality 무시됨)
+./target/release/image_converter -i photo.webp -o photo.png -f png
+
+# JPEG 로 변환 (알파 채널이 있으면 자동 RGB 변환)
+./target/release/image_converter -i icon.png -o icon.jpg -f jpeg -q 85
+
+# TIFF/BMP 입력도 그대로 지원
+./target/release/image_converter -i scan.tiff -o scan.webp -f webp -q 85
 ```
 
 ### 명령줄 모드 - 디렉토리 일괄 변환
@@ -80,8 +101,8 @@ RAYON_NUM_THREADS=4 ./target/release/image_converter -i photos -o photos_webp -f
 - `-I, --interactive`: 대화형 모드 실행
 - `-i, --input <PATH>`: 입력 이미지 파일 또는 디렉토리 경로
 - `-o, --output <PATH>`: 출력 파일 또는 디렉토리 경로
-- `-f, --format <FORMAT>`: 출력 형식 (webp 또는 avif)
-- `-q, --quality <QUALITY>`: 변환 품질 (1-100, 기본값: 90)
+- `-f, --format <FORMAT>`: 출력 형식 (`png`, `jpg`, `jpeg`, `webp`, `avif`)
+- `-q, --quality <QUALITY>`: 변환 품질 1-100 (기본값: 90, **PNG 출력 시 무손실이라 무시됨**)
 - `-r, --recursive`: 디렉토리 입력 시 하위 폴더까지 재귀 변환
 
 ## 💡 예제 출력

--- a/TESTING.md
+++ b/TESTING.md
@@ -117,6 +117,28 @@ cargo test --release
     - 존재하지 않는 입력 파일 처리 테스트
     - 파일이 없을 때 적절한 에러가 발생하는지 확인
 
+### 🔁 다중 포맷 입출력 테스트
+
+13. **`test_png_output_from_webp_input`**
+    - WebP → PNG 역변환이 동작하는지 확인 (`encode_to` 의 PNG 분기 + WebP 디코딩)
+    - 출력 파일이 PNG 매직 바이트(`89 50 4E 47`) 로 시작하는지 검증
+
+14. **`test_jpeg_output_from_png_input`**
+    - PNG → JPEG 변환이 동작하는지 확인
+    - 출력 파일이 JPEG 매직 바이트(`FF D8 FF`) 로 시작하는지 검증
+
+15. **`test_jpg_alias_for_jpeg`**
+    - 포맷 인자 `"jpg"` 와 `"jpeg"` 가 같은 JPEG 인코딩 분기로 매핑되는지 확인
+
+16. **`test_tiff_input_to_webp`**
+    - TIFF 입력이 디코딩되어 WebP 로 변환되는지 확인 (`is_supported_image` 화이트리스트 + `image::open` TIFF 디코더)
+
+17. **`test_bmp_input_to_jpeg`**
+    - BMP 입력이 디코딩되어 JPEG 로 변환되는지 확인
+
+18. **`test_batch_mixed_input_formats`**
+    - PNG + WebP + TIFF + BMP 4종이 한 디렉토리에 섞여 있을 때 모두 PNG 로 일괄 변환되는지 확인 (배치 모드의 입력 화이트리스트 + 다중 디코더 결합 검증)
+
 ## 테스트 매크로
 
 ### `test_description!`
@@ -175,7 +197,7 @@ fn test_new_feature() {
 
 ## 테스트 커버리지
 
-현재 테스트는 다음 영역을 커버합니다 (총 12개):
+현재 테스트는 다음 영역을 커버합니다 (총 18개):
 - ✅ 파일 크기 포맷팅
 - ✅ WebP / AVIF 단일 변환
 - ✅ 품질 파라미터 검증
@@ -183,11 +205,14 @@ fn test_new_feature() {
 - ✅ 비이미지 파일 자동 스킵
 - ✅ 빈 디렉토리 처리
 - ✅ 에러 처리 (지원하지 않는 형식, 존재하지 않는 파일)
+- ✅ PNG / JPEG 출력 (WebP → PNG 역변환, PNG → JPEG, jpg 별칭)
+- ✅ TIFF / BMP 입력 디코딩
+- ✅ 혼합 입력 포맷 일괄 변환 (PNG + WebP + TIFF + BMP → PNG)
 
 향후 추가할 수 있는 테스트:
-- 다양한 입력 확장자 (JPG, JPEG)
+- AVIF 입력 디코딩 (`libdav1d` 의존성 추가 후)
+- JPG/JPEG 단일 입력 명시 케이스 (현재는 혼합 배치로 간접 커버)
 - 일괄 변환 중 일부 파일이 손상되어 실패할 때의 동작
 - 대용량 이미지 처리
-- 동시 변환 처리
 - 메모리 사용량 테스트
 - 대화형 모드 테스트

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -19,13 +19,16 @@ pub struct BatchSummary {
 }
 
 /// 입력 파일이 지원하는 이미지 확장자인지 확인
+/// AVIF 입력은 dav1d 시스템 의존성을 요구해서 별도 PR 로 분리됨
 fn is_supported_image(path: &Path) -> bool {
     matches!(
         path.extension()
             .and_then(|e| e.to_str())
             .map(|s| s.to_lowercase())
             .as_deref(),
-        Some("png" | "jpg" | "jpeg")
+        Some(
+            "png" | "jpg" | "jpeg" | "webp" | "tiff" | "tif" | "bmp" | "ico"
+        )
     )
 }
 
@@ -105,7 +108,7 @@ pub fn convert_directory(
 
     if files.is_empty() {
         println!(
-            "\n{} 변환 가능한 이미지(.png/.jpg/.jpeg)가 없습니다.",
+            "\n{} 변환 가능한 이미지(.png/.jpg/.jpeg/.webp/.tiff/.bmp/.ico)가 없습니다.",
             "⚠️".bright_yellow()
         );
         return Ok(BatchSummary {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,8 +1,9 @@
 use colored::*;
-use image::{DynamicImage, GenericImageView};
+use image::{DynamicImage, GenericImageView, ImageOutputFormat};
 use indicatif::{ProgressBar, ProgressStyle};
 use ravif::{Encoder as AvifEncoder, Img, RGBA8};
 use std::fs;
+use std::io::Cursor;
 use webp::Encoder as WebpEncoder;
 
 use crate::error::{ConverterError, Result};
@@ -35,6 +36,20 @@ fn encode_to(img: &DynamicImage, format: &str, quality: f32) -> Result<Vec<u8>> 
             let encoder = AvifEncoder::new().with_quality(quality).with_speed(4);
             let res = encoder.encode_rgba(Img::new(&pixels, width as usize, height as usize))?;
             Ok(res.avif_file)
+        }
+        "png" => {
+            // PNG 는 무손실 — quality 는 의미 없음 (조용히 무시)
+            let mut buf: Vec<u8> = Vec::new();
+            img.write_to(&mut Cursor::new(&mut buf), ImageOutputFormat::Png)?;
+            Ok(buf)
+        }
+        "jpg" | "jpeg" => {
+            // JPEG 는 알파 채널을 가질 수 없으므로 RGB 로 다운샘플 후 인코딩
+            let q = quality.clamp(1.0, 100.0).round() as u8;
+            let rgb = DynamicImage::ImageRgb8(img.to_rgb8());
+            let mut buf: Vec<u8> = Vec::new();
+            rgb.write_to(&mut Cursor::new(&mut buf), ImageOutputFormat::Jpeg(q))?;
+            Ok(buf)
         }
         _ => Err(ConverterError::UnsupportedFormat(format.to_string())),
     }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -53,7 +53,7 @@ pub fn interactive_mode() -> crate::error::Result<()> {
     };
 
     // 출력 형식 선택
-    let formats = vec!["WebP", "AVIF"];
+    let formats = vec!["WebP", "AVIF", "PNG", "JPEG"];
     let format_selection = Select::with_theme(&ColorfulTheme::default())
         .with_prompt("출력 형식을 선택하세요")
         .items(&formats)
@@ -62,35 +62,43 @@ pub fn interactive_mode() -> crate::error::Result<()> {
 
     let format = formats[format_selection].to_lowercase();
 
-    // 품질 선택
-    let quality_options = vec![
-        "최고 품질 (100%)",
-        "높음 (90%)",
-        "보통 (80%)",
-        "낮음 (70%)",
-        "사용자 지정",
-    ];
-    let quality_selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("변환 품질을 선택하세요")
-        .items(&quality_options)
-        .default(1)
-        .interact()?;
+    // 품질 선택 — PNG 는 무손실이라 의미 없으므로 스킵
+    let quality = if format == "png" {
+        println!(
+            "  {} PNG 는 무손실 포맷이라 품질 설정이 적용되지 않습니다.",
+            "ℹ️".bright_blue()
+        );
+        100.0
+    } else {
+        let quality_options = vec![
+            "최고 품질 (100%)",
+            "높음 (90%)",
+            "보통 (80%)",
+            "낮음 (70%)",
+            "사용자 지정",
+        ];
+        let quality_selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("변환 품질을 선택하세요")
+            .items(&quality_options)
+            .default(1)
+            .interact()?;
 
-    let quality = match quality_selection {
-        0 => 100.0,
-        1 => 90.0,
-        2 => 80.0,
-        3 => 70.0,
-        _ => Input::with_theme(&ColorfulTheme::default())
-            .with_prompt("품질 값을 입력하세요 (1-100)")
-            .validate_with(|input: &String| -> Result<(), &str> {
-                match input.parse::<f32>() {
-                    Ok(q) if q >= 1.0 && q <= 100.0 => Ok(()),
-                    _ => Err("1-100 사이의 숫자를 입력하세요"),
-                }
-            })
-            .interact_text()?
-            .parse::<f32>()?,
+        match quality_selection {
+            0 => 100.0,
+            1 => 90.0,
+            2 => 80.0,
+            3 => 70.0,
+            _ => Input::with_theme(&ColorfulTheme::default())
+                .with_prompt("품질 값을 입력하세요 (1-100)")
+                .validate_with(|input: &String| -> Result<(), &str> {
+                    match input.parse::<f32>() {
+                        Ok(q) if q >= 1.0 && q <= 100.0 => Ok(()),
+                        _ => Err("1-100 사이의 숫자를 입력하세요"),
+                    }
+                })
+                .interact_text()?
+                .parse::<f32>()?,
+        }
     };
 
     // 출력 경로

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 
 use image_converter::{convert_directory, convert_image, interactive::interactive_mode};
 
-/// PNG, JPG, JPEG 이미지를 WebP와 AVIF로 변환합니다 (단일 파일 + 디렉토리 일괄)
+/// PNG/JPG/JPEG/WebP/TIFF/BMP/ICO 이미지를 PNG/JPG/WebP/AVIF 로 변환합니다 (단일 파일 + 디렉토리 일괄)
 #[derive(Parser, Debug)]
-#[command(name = "image_converter", version = "2.2", about, long_about = None)]
+#[command(name = "image_converter", version = "2.3", about, long_about = None)]
 struct Cli {
     /// 대화형 모드로 실행
     #[arg(short = 'I', long)]
@@ -20,11 +20,11 @@ struct Cli {
     #[arg(short, long, value_name = "PATH", required_unless_present = "interactive")]
     output: Option<String>,
 
-    /// 출력 포맷 (webp 또는 avif)
+    /// 출력 포맷 (png, jpg, jpeg, webp, avif)
     #[arg(short, long, value_name = "FORMAT", required_unless_present = "interactive")]
     format: Option<String>,
 
-    /// 변환 품질 (1-100, 기본값: 90)
+    /// 변환 품질 1-100 (PNG 는 무손실이라 무시됨, 기본값: 90)
     #[arg(short, long, default_value_t = 90.0)]
     quality: f32,
 

--- a/src/tests/integration_tests.rs
+++ b/src/tests/integration_tests.rs
@@ -340,3 +340,189 @@ fn test_batch_empty_directory() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_png_output_from_webp_input() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("WebP → PNG 역변환 테스트");
+    test_step!("WebP 파일을 PNG 로 되돌릴 수 있는지 확인");
+
+    let temp_dir = TempDir::new()?;
+    let png_seed = temp_dir.path().join("seed.png");
+    let webp_path = temp_dir.path().join("intermediate.webp");
+    let restored_path = temp_dir.path().join("restored.png");
+
+    // 1) PNG 시드 → 2) WebP 로 변환 → 3) WebP 를 다시 PNG 로
+    create_test_image(png_seed.to_str().unwrap(), 80, 80)?;
+    convert_image_silent(
+        png_seed.to_str().unwrap(),
+        webp_path.to_str().unwrap(),
+        "webp",
+        90.0,
+    )?;
+    test_success!("WebP 중간 파일 생성");
+
+    convert_image_silent(
+        webp_path.to_str().unwrap(),
+        restored_path.to_str().unwrap(),
+        "png",
+        90.0,
+    )?;
+
+    assert!(restored_path.exists(), "복원된 PNG 파일이 생성되어야 함");
+
+    // PNG 시그니처(0x89 P N G) 검증
+    let bytes = fs::read(&restored_path)?;
+    assert_eq!(
+        &bytes[0..4],
+        &[0x89, 0x50, 0x4E, 0x47],
+        "PNG 매직 바이트 확인"
+    );
+    test_success!("WebP → PNG 역변환 + 시그니처 확인");
+
+    Ok(())
+}
+
+#[test]
+fn test_jpeg_output_from_png_input() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("PNG → JPEG 변환 테스트");
+    test_step!("PNG 입력을 JPEG 로 변환할 수 있는지 확인");
+
+    let temp_dir = TempDir::new()?;
+    let png_path = temp_dir.path().join("test.png");
+    let jpg_path = temp_dir.path().join("test.jpg");
+
+    create_test_image(png_path.to_str().unwrap(), 100, 100)?;
+
+    convert_image_silent(
+        png_path.to_str().unwrap(),
+        jpg_path.to_str().unwrap(),
+        "jpeg",
+        85.0,
+    )?;
+
+    assert!(jpg_path.exists(), "JPEG 파일이 생성되어야 함");
+
+    // JPEG 시그니처(FF D8 FF) 검증
+    let bytes = fs::read(&jpg_path)?;
+    assert_eq!(&bytes[0..3], &[0xFF, 0xD8, 0xFF], "JPEG 매직 바이트 확인");
+    test_success!("PNG → JPEG 변환 + 시그니처 확인");
+
+    Ok(())
+}
+
+#[test]
+fn test_jpg_alias_for_jpeg() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("'jpg' 가 'jpeg' 와 동일하게 처리되는지 테스트");
+
+    let temp_dir = TempDir::new()?;
+    let png_path = temp_dir.path().join("test.png");
+    let jpg_path = temp_dir.path().join("test.jpg");
+
+    create_test_image(png_path.to_str().unwrap(), 60, 60)?;
+
+    convert_image_silent(
+        png_path.to_str().unwrap(),
+        jpg_path.to_str().unwrap(),
+        "jpg",
+        85.0,
+    )?;
+
+    assert!(jpg_path.exists());
+    let bytes = fs::read(&jpg_path)?;
+    assert_eq!(&bytes[0..3], &[0xFF, 0xD8, 0xFF]);
+    test_success!("'jpg' 별칭 정상 동작");
+
+    Ok(())
+}
+
+#[test]
+fn test_tiff_input_to_webp() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("TIFF 입력을 WebP 로 변환");
+
+    let temp_dir = TempDir::new()?;
+    let tiff_path = temp_dir.path().join("test.tiff");
+    let webp_path = temp_dir.path().join("test.webp");
+
+    // ImageBuffer::save 가 확장자로 포맷 추론 → TIFF 로 저장됨
+    create_test_image(tiff_path.to_str().unwrap(), 80, 80)?;
+
+    convert_image_silent(
+        tiff_path.to_str().unwrap(),
+        webp_path.to_str().unwrap(),
+        "webp",
+        85.0,
+    )?;
+    assert!(webp_path.exists());
+    test_success!("TIFF → WebP 변환 성공");
+
+    Ok(())
+}
+
+#[test]
+fn test_bmp_input_to_jpeg() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("BMP 입력을 JPEG 로 변환");
+
+    let temp_dir = TempDir::new()?;
+    let bmp_path = temp_dir.path().join("test.bmp");
+    let jpg_path = temp_dir.path().join("test.jpg");
+
+    create_test_image(bmp_path.to_str().unwrap(), 60, 60)?;
+
+    convert_image_silent(
+        bmp_path.to_str().unwrap(),
+        jpg_path.to_str().unwrap(),
+        "jpeg",
+        85.0,
+    )?;
+    assert!(jpg_path.exists());
+    let bytes = fs::read(&jpg_path)?;
+    assert_eq!(&bytes[0..3], &[0xFF, 0xD8, 0xFF]);
+    test_success!("BMP → JPEG 변환 성공");
+
+    Ok(())
+}
+
+#[test]
+fn test_batch_mixed_input_formats() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("일괄 변환에서 다양한 입력 포맷 혼합 테스트");
+    test_step!("PNG + WebP + TIFF + BMP 가 한 디렉토리에 있을 때 모두 PNG 로 변환되는지");
+
+    let temp_dir = TempDir::new()?;
+    let input_dir = temp_dir.path().join("mixed_input");
+    let output_dir = temp_dir.path().join("mixed_output");
+    fs::create_dir(&input_dir)?;
+
+    // PNG, TIFF, BMP 는 ImageBuffer::save 가 직접 만들 수 있음
+    create_test_image(input_dir.join("a.png").to_str().unwrap(), 50, 50)?;
+    create_test_image(input_dir.join("b.tiff").to_str().unwrap(), 50, 50)?;
+    create_test_image(input_dir.join("c.bmp").to_str().unwrap(), 50, 50)?;
+
+    // WebP 는 별도 webp 크레이트로 인코딩 — 임시 PNG 를 거쳐 생성
+    let temp_png = temp_dir.path().join("temp_seed.png");
+    create_test_image(temp_png.to_str().unwrap(), 50, 50)?;
+    convert_image_silent(
+        temp_png.to_str().unwrap(),
+        input_dir.join("d.webp").to_str().unwrap(),
+        "webp",
+        90.0,
+    )?;
+    test_success!("혼합 입력 4개 (PNG/TIFF/BMP/WebP) 준비 완료");
+
+    let summary = convert_directory(
+        input_dir.to_str().unwrap(),
+        output_dir.to_str().unwrap(),
+        "png",
+        100.0,
+        false,
+    )?;
+
+    assert_eq!(summary.total_files, 4, "4개 파일이 처리 대상");
+    assert_eq!(summary.succeeded, 4, "4개 모두 성공");
+    assert!(output_dir.join("a.png").exists());
+    assert!(output_dir.join("b.png").exists());
+    assert!(output_dir.join("c.png").exists());
+    assert!(output_dir.join("d.png").exists());
+    test_success!("4종 입력 포맷 모두 PNG 로 변환 성공");
+
+    Ok(())
+}


### PR DESCRIPTION
- `src/converter.rs` — `encode_to()` 에 `png` / `jpg|jpeg` 분기 추가. PNG 는 `ImageOutputFormat::Png` 로 무손실 인코딩 (quality 인자 무시), JPEG 는 `to_rgb8()` 로 RGB 다운샘플 후 `ImageOutputFormat::Jpeg(quality.clamp(1, 100) as u8)`. `jpg` / `jpeg` 는 같은 분기로 처리
- `src/batch.rs` — `is_supported_image()` 화이트리스트에 `webp / tiff / tif / bmp / ico` 추가. 빈 디렉토리 안내 메시지의 확장자 목록도 갱신. AVIF 입력은 `libdav1d` 시스템 의존성 부담으로 별도 PR 후보로 분리
- `src/interactive.rs` — 출력 포맷 선택지 → `WebP / AVIF / PNG / JPEG`. PNG 선택 시 quality 단계는 자동 스킵 + "무손실이라 적용 안 됨" 한 줄 안내
- `src/main.rs` — doc 주석 / `-f` 값 설명 / `-q` 설명(PNG 무손실 안내) / 버전 `2.2 → 2.3`
- `Cargo.toml` 변경 없음 — 모든 신규 포맷이 `image` 0.24.9 default features 로 이미 가능 (WebP 디코딩 / PNG · JPEG 인코딩 / TIFF · BMP · ICO 디코딩)

회귀 + 신규 검증:
- 통합 테스트 6개 추가 (12 → 18, 모두 통과)
  - `test_png_output_from_webp_input` — WebP → PNG 역변환 + PNG 시그니처(`89 50 4E 47`) 검증
  - `test_jpeg_output_from_png_input` — PNG → JPEG + JPEG 시그니처(`FF D8 FF`) 검증
  - `test_jpg_alias_for_jpeg` — `"jpg"` 가 `"jpeg"` 와 같은 분기로 매핑되는지 확인
  - `test_tiff_input_to_webp` — TIFF 디코딩
  - `test_bmp_input_to_jpeg` — BMP 디코딩
  - `test_batch_mixed_input_formats` — PNG + WebP + TIFF + BMP 혼합 디렉토리를 일괄 PNG 로 변환
- `cargo build --release` 경고 없이 통과
- `--help` 출력에 새 포맷 / PNG 무손실 안내 반영 확인

문서 갱신:
- `README.md` — 지원 포맷 매트릭스 표 추가, 명령줄 예제에 역변환·JPEG·TIFF 케이스 추가, 옵션 설명 갱신
- `CLAUDE.md` — 프로젝트 개요에 양방향 명시, 모듈 코멘트 갱신, 향후 후보에 AVIF 입력 / HEIC 추가
- `PROJECT_STRUCTURE.md` — `encode_to()` / `is_supported_image()` / 대화형 모드 책임 갱신
- `TESTING.md` — 새 테스트 6개 설명 + 커버리지 12 → 18
- `MEMORY.md` — 작업 로그 / A안 채택 결정 기록 / 진행 항목 갱신