### PR TITLE
feat: AVIF 입력 디코딩 추가 — image avif-decoder feature + ravif 8-bit 강제

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,16 @@
 # Image Converter
 
-여러 이미지 포맷 (PNG/JPG/JPEG/WebP/TIFF/BMP/ICO) 을 PNG/JPG/WebP/AVIF 로 양방향 변환하는 Rust CLI 도구.
+여러 이미지 포맷 (PNG/JPG/JPEG/WebP/AVIF/TIFF/BMP/ICO) 을 PNG/JPG/WebP/AVIF 로 양방향 변환하는 Rust CLI 도구.
 
 ## 프로젝트 개요
 
 - **언어/도구**: Rust (edition 2021)
-- **지원 입력**: PNG, JPG, JPEG, WebP, TIFF, BMP, ICO (`image` 크레이트 default features)
+- **지원 입력**: PNG, JPG, JPEG, WebP, AVIF (8-bit), TIFF, BMP, ICO
 - **지원 출력**: PNG, JPG/JPEG, WebP, AVIF
-- **AVIF 입력은 미지원** — `libdav1d` 시스템 의존성을 요구해서 별도 PR 후보
+- **AVIF 인코딩은 8-bit 로 고정** — `image` 0.24 의 AVIF 디코더가 8-bit 만 지원해서 라운드트립 호환성 유지
 - **모드**: 단일 파일 변환 + 디렉토리 일괄 변환 (재귀 옵션)
 - **인터페이스**: 명령줄 모드 (`-i/-o/-f/-q/-r`) + 대화형 모드 (`-I`)
-- **변환 엔진**: WebP 인코딩은 `webp` 크레이트, AVIF 인코딩은 `ravif` (rav1e 기반), 그 외 PNG/JPEG/TIFF/BMP/ICO 디코딩과 PNG/JPEG 인코딩은 `image` 크레이트
+- **변환 엔진**: WebP 인코딩은 `webp` 크레이트, AVIF 인코딩은 `ravif` (rav1e 기반), AVIF 디코딩은 `image` 의 `avif-decoder` feature (`dav1d` 시스템 의존), 그 외 PNG/JPEG/WebP/TIFF/BMP/ICO 디코딩과 PNG/JPEG 인코딩은 `image` 크레이트
 
 세부 사용법은 `README.md` 참고.
 
@@ -23,13 +23,13 @@ src/
 ├── error.rs           # ConverterError + Result 타입 (thiserror 기반)
 ├── converter.rs       # 단일 변환. encode_to() 가 webp/avif/png/jpg|jpeg 분기를
 │                      # 처리하고, convert_image(UI 포함) / convert_image_silent
-│                      # (조용함) 가 동일 내부를 공유
+│                      # (조용함) 가 동일 내부를 공유. AVIF 인코딩은 8-bit 고정
 ├── batch.rs           # 디렉토리 일괄 변환 (walkdir + rayon 병렬, 재귀 옵션, 구조 미러링).
-│                      # 입력 화이트리스트: png/jpg/jpeg/webp/tiff/tif/bmp/ico
+│                      # 입력 화이트리스트: png/jpg/jpeg/webp/avif/tiff/tif/bmp/ico
 ├── interactive.rs     # 대화형 모드 (단일/디렉토리 선택 → 출력 포맷 → 옵션 → 실행).
 │                      # PNG 출력 시 quality 단계는 자동 스킵
 ├── utils.rs           # format_file_size 등 헬퍼
-└── tests/             # 단위 + 통합 테스트 (총 18개)
+└── tests/             # 단위 + 통합 테스트 (총 19개)
 ```
 
 세부 책임은 `PROJECT_STRUCTURE.md` 참고.
@@ -37,10 +37,18 @@ src/
 ## 시스템 요구사항
 
 - **Rust toolchain** (cargo 1.94+)
-- **nasm** — AVIF 인코더(`rav1e`) 빌드에 필요. WSL/Ubuntu 에서:
-  ```bash
-  sudo apt-get install -y nasm
-  ```
+- **nasm** — AVIF 인코더(`rav1e`) 빌드에 필요
+- **libdav1d** — AVIF 디코더(`dav1d-sys`) 빌드에 필요 (`pkg-config` 로 동적 링크)
+
+```bash
+# WSL/Ubuntu
+sudo apt-get install -y nasm libdav1d-dev
+
+# macOS
+brew install nasm dav1d
+```
+
+빌드 시 `pkg-config: Package dav1d was not found` 에러가 나면 `libdav1d-dev` (Linux) / `dav1d` (macOS) 가 빠졌다는 신호.
 
 ## 개발 명령어
 
@@ -104,8 +112,8 @@ Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 (우선순위 추정 순)
 
-1. **AVIF 입력 지원** — `image` 크레이트의 `avif-decoder` feature 활성화 + `libdav1d-dev` (apt) / `dav1d` (brew) 시스템 의존성 추가. `is_supported_image()` 화이트리스트에 `"avif"` 한 단어 추가하면 됨
-2. **`--threads` CLI 옵션** — `RAYON_NUM_THREADS` 환경변수 외에 명시적 플래그
+1. **`--threads` CLI 옵션** — `RAYON_NUM_THREADS` 환경변수 외에 명시적 플래그
+2. **`image` 0.25 업그레이드** — 0.24 의 AVIF 디코더가 8-bit 만 지원하는 한계 해소 (10-bit AVIF 입력 지원). breaking change 가 있어 별도 작업
 3. **JPG/JPEG 단일 입력 회귀 테스트** — 현재는 혼합 배치 / 다른 포맷 출력으로만 간접 커버. 명시적 단일 케이스
 4. **HEIC 입력** — iPhone 사진 변환용. `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트 도입 필요
 5. **대화형 모드 테스트** — 현재 미커버

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aligned"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +133,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-data"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca67ba5d317924c02180c576157afd54babe48a76ebc66ce6d34bb8ba08308e"
+dependencies = [
+ "byte-slice-cast",
+ "bytes",
+ "num-derive",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "av-scenechange"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +207,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "bitstream-io"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
 name = "bytemuck"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +269,16 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -356,6 +412,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "dav1d"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c3f80814db85397819d464bb553268992c393b4b3b5554b89c1655996d5926"
+dependencies = [
+ "av-data",
+ "bitflags 2.9.1",
+ "dav1d-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "dav1d-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c91aea6668645415331133ed6f8ddf0e7f40160cd97a12d59e68716a58704b"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "dcv-color-primitives"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ad62edfed069700a5b33af6babd29c498d7e33eb01d96ffa8841ee1841634c"
+dependencies = [
+ "paste",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +489,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +517,15 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "fallible_collections"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
+dependencies = [
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -489,6 +592,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,9 +621,12 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
+ "dav1d",
+ "dcv-color-primitives",
  "exr",
  "gif",
  "jpeg-decoder",
+ "mp4parse",
  "num-traits",
  "png",
  "qoi",
@@ -534,6 +655,16 @@ name = "imgref"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+]
 
 [[package]]
 name = "indicatif"
@@ -695,6 +826,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mp4parse"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570"
+dependencies = [
+ "bitreader",
+ "byteorder",
+ "fallible_collections",
+ "log",
+ "num-traits",
+ "static_assertions",
+]
+
+[[package]]
 name = "nasm-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +949,12 @@ name = "pastey"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a8cb46bdc156b1c90460339ae6bfd45ba0394e5effbaa640badb4987fdc261"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
@@ -1027,6 +1178,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1267,25 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "system-deps"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"
@@ -1147,6 +1352,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1418,18 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1374,6 +1630,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "image_converter"
 path = "src/main.rs"
 
 [dependencies]
-image = "0.24.2"
+image = { version = "0.24.2", features = ["avif-decoder"] }
 webp = "0.2.0"
 ravif = "0.12.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,6 +12,19 @@
 
 ## 최근 작업 로그
 
+### 2026-04-30 — `feat: AVIF 입력 디코딩 추가 (B안)` (PR 진행 중)
+
+- `Cargo.toml` — `image = { version = "0.24.2", features = ["avif-decoder"] }` 로 변경. `mp4parse` / `dcv-color-primitives` / `dav1d-sys` / `dav1d` 의존성 자동 추가
+- 시스템 의존성 추가: `libdav1d-dev` (apt) / `dav1d` (brew). 빌드 시 `pkg-config` 로 동적 링크
+- `src/batch.rs` `is_supported_image()` 화이트리스트에 `"avif"` 한 단어 추가 + 빈 디렉토리 안내 메시지 갱신
+- **호환성 이슈 + 해결**: `ravif` default 인코딩이 10-bit AVIF 를 만들지만 `image` 0.24 의 AVIF 디코더는 8-bit 만 지원해서 라운드트립이 깨졌음. `src/converter.rs` AVIF 분기에 `.with_bit_depth(BitDepth::Eight)` 추가하여 인코딩을 8-bit 로 강제. `use ravif::BitDepth` import 추가
+- `src/converter.rs` 의 AVIF 인코더 호출에 8-bit 강제 결정 이유 한 줄 주석
+- `ravif::Encoder::with_depth(Some(8))` 는 deprecated 됐고 `with_bit_depth(BitDepth::Eight)` 가 신 API
+- 통합 테스트 1개 추가 + 1개 갱신 (총 18 → 19, 모두 통과):
+  - 신규 `test_avif_input_to_png` — PNG 시드를 AVIF 로 인코딩 → 다시 PNG 로 디코딩하는 라운드트립
+  - 갱신 `test_batch_mixed_input_formats` — 입력 포맷 4개 (PNG/WebP/TIFF/BMP) → 5개 (+ AVIF)
+- README/CLAUDE/PROJECT_STRUCTURE/TESTING 갱신 — 매트릭스 표 AVIF 입력 ✅, 시스템 요구사항에 `libdav1d-dev` 추가, AVIF 8-bit 한계 명시, 향후 후보에 `image` 0.25 업그레이드 추가
+
 ### 2026-04-30 — `feat: 다중 입출력 포맷 지원 (역변환 + 추가 입력)` (PR 진행 중)
 
 - `Cargo.toml` **변경 없음** — 모든 신규 포맷이 `image` 0.24.9 의 default features 로 이미 가능
@@ -79,7 +92,9 @@
 
 ## 결정 기록
 
-- **A안 채택 (AVIF 입력 제외)** — `image` 크레이트의 `avif-decoder` feature 는 `dav1d` 시스템 라이브러리 (`libdav1d-dev` apt / `dav1d` brew) 를 요구. 현재 `nasm` 한 가지만 시스템 의존성으로 잡혀 있는 깔끔함을 유지하기 위해 1단계에서 AVIF 입력만 제외. WebP 디코딩은 `image` 0.24 default features 에 포함되어 Cargo.toml 변경 없이 동작.
+- **AVIF 인코딩을 8-bit 로 강제 (`with_bit_depth(BitDepth::Eight)`)** — `ravif` default 가 10-bit (Auto = Ten) 인데 `image` 0.24 AVIF 디코더는 8-bit 만 지원. 강제 안 하면 우리가 만든 AVIF 를 우리가 디코딩 못 하는 라운드트립 모순 발생. 일반 사진 변환 용도에서는 8-bit 로도 충분하고 호환성(타 뷰어/디코더) 도 더 좋음. 단점은 HDR / 부드러운 그라디언트 케이스에서 약간 손해 — `image` 0.25 업그레이드로 10-bit 디코딩 지원되면 default 풀어줄 후보.
+- **외부 10-bit AVIF 입력은 명시적으로 미지원** — `image` 0.24 의 디코더 한계. 사용자가 다른 도구로 만든 10-bit AVIF 를 입력으로 쓰면 `Only 8 bit depth is supported but was 10` 에러. README 매트릭스 표 비고에 한 줄 명시. `image` 0.25 업그레이드를 향후 후보로 정리.
+- **A안 채택 (1단계에서 AVIF 입력 제외)** — `image` 크레이트의 `avif-decoder` feature 는 `dav1d` 시스템 라이브러리 (`libdav1d-dev` apt / `dav1d` brew) 를 요구. 1단계는 시스템 의존성 추가 없는 작업으로 분리하고, B안 (AVIF 입력) 은 별도 PR 로 진행해 의존성 변경의 의도를 명확히 함.
 - **PNG quality 는 조용히 무시** — `encode_to("png", ...)` 가 quality 인자를 받지만 사용하지 않음. CLI 와 대화형 모드에서 사용자에게 "무손실이라 적용 안 됨" 한 줄 안내 + `-q` doc 주석에도 명시. 에러로 거부하지 않는 이유는 배치 모드에서 한 quality 값을 여러 출력 포맷에 공통 적용하는 흐름을 깨지 않기 위함.
 - **JPEG 출력 시 `to_rgb8()` 로 명시적 RGB 다운샘플** — `image` 의 `write_to(..., ImageOutputFormat::Jpeg(q))` 는 RGBA 입력도 받지만 동작이 버전에 따라 다를 수 있음. 명시적으로 `DynamicImage::ImageRgb8(img.to_rgb8())` 로 변환 후 인코딩하여 알파 채널 처리를 확정적으로 만듦. 알파 픽셀은 검정 배경 위에 합성된 형태로 처리됨 (image 크레이트 기본 동작).
 - **`jpg` 와 `jpeg` 를 같은 분기로** — `match` 의 or-pattern (`"jpg" | "jpeg"`) 으로 한 분기에서 처리. 사용자 친화적이면서 코드 중복 없음. 출력 확장자도 사용자가 명시한 그대로 사용 (둘 다 동일 JPEG 컨테이너).
@@ -104,13 +119,17 @@
 - [x] **커스텀 에러 타입 (`thiserror`)** — 완료. `ConverterError` enum + 8 variant.
 - [x] **일괄 변환 병렬화 (`rayon`)** — 완료. 16코어에서 8장 AVIF 변환 8.3배 ↑.
 - [x] **다중 입출력 포맷 지원 (A안)** — 완료. PNG/JPG/JPEG 출력 + WebP/TIFF/BMP/ICO 입력 추가. 18 테스트 통과.
-- [ ] **AVIF 입력 (B안 후속 PR)** — `Cargo.toml` 에 `image = { ..., features = ["avif-decoder"] }` + `is_supported_image()` 화이트리스트에 `"avif"` 한 단어 + `libdav1d` 시스템 의존성 안내. 매우 작은 PR.
+- [x] **AVIF 입력 (B안)** — 완료. `avif-decoder` feature 활성화 + `libdav1d-dev` 의존성 추가. 라운드트립을 위해 ravif 인코딩을 8-bit 로 강제. 19 테스트 통과.
 - [ ] **`--threads` CLI 옵션** — 현재는 `RAYON_NUM_THREADS` 환경변수만. 작은 추가 작업.
+- [ ] **`image` 0.25 업그레이드** — 10-bit AVIF 디코딩 지원. breaking change 가 있어 별도 작업. 업그레이드 후 ravif 의 8-bit 강제도 풀어줄 수 있음
 - [ ] **JPG/JPEG 단일 입력 명시 회귀 테스트** — 다중 포맷 PR 에서 혼합 배치로 간접 커버. 명시적 단일 케이스는 별도.
 - [ ] **HEIC 입력** — `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트. 부담 큼.
 - [ ] **대화형 모드 테스트** — `dialoguer` 입력 모킹이 까다로워 우선순위 낮음.
 
 ## 환경 메모
 
-- WSL2 (Ubuntu) 에서 빌드 시 `nasm` 패키지 필요 (rav1e/AVIF). `sudo apt-get install -y nasm`.
-- 새 장비 setup 시 `cargo build --release` 가 nasm 없이 실패하면 위 메시지로 안내됨.
+- 빌드 시 두 시스템 라이브러리가 필요:
+  - `nasm` — rav1e (AVIF 인코딩) 빌드용
+  - `libdav1d-dev` (apt) / `dav1d` (brew) — dav1d-sys (AVIF 디코딩) 빌드용. `pkg-config` 로 동적 링크
+- 한 줄 설치: `sudo apt-get install -y nasm libdav1d-dev` (Ubuntu/WSL) / `brew install nasm dav1d` (macOS)
+- 빌드 실패 시그널: `Package dav1d was not found in the pkg-config search path` 는 `libdav1d-dev` 누락. nasm 누락은 rav1e 컴파일 단계에서 명확한 에러로 안내됨.

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -45,7 +45,7 @@ image_converter/
 
 - `encode_to`: 메모리 이미지를 WebP/AVIF/PNG/JPG/JPEG 바이트로 인코딩 (내부 헬퍼)
   - WebP: `webp::Encoder::from_image` + `encode(quality)`
-  - AVIF: `ravif::Encoder` (rav1e 기반, RGBA 추출 후 인코딩)
+  - AVIF: `ravif::Encoder` (rav1e 기반, RGBA 추출 후 인코딩) — `with_bit_depth(BitDepth::Eight)` 로 **8-bit 강제** (image 0.24 디코더와 호환성 유지)
   - PNG: `image` 크레이트의 `write_to(&mut Cursor, ImageOutputFormat::Png)` — 무손실, quality 무시
   - JPG/JPEG: 알파 채널을 가질 수 없어 `to_rgb8()` 으로 다운샘플 후 `ImageOutputFormat::Jpeg(quality_u8)`
 - `convert_image`: 진행률 + 결과 출력 포함
@@ -55,8 +55,7 @@ image_converter/
 ### `batch.rs` (디렉토리 일괄 변환)
 
 - `convert_directory`: 입력 디렉토리에서 지원 포맷만 골라 **rayon 으로 병렬** 변환
-  - 입력 화이트리스트: `png`/`jpg`/`jpeg`/`webp`/`tiff`/`tif`/`bmp`/`ico`
-  - AVIF 는 디코더가 `libdav1d` 시스템 의존성을 요구해서 입력 화이트리스트에서 제외 (별도 PR 후보)
+  - 입력 화이트리스트: `png`/`jpg`/`jpeg`/`webp`/`avif`/`tiff`/`tif`/`bmp`/`ico`
 - 각 파일은 `process_one` 헬퍼가 처리하고 `Option<ConvertStats>` 를 반환 — 한 파일이 실패해도 나머지는 그대로 진행
 - 결과는 직렬 합산하여 `BatchSummary` 통계로 반환
 - 진행률 바 (`indicatif::ProgressBar`) 와 `pb.println` 은 thread-safe (내부 Mutex)
@@ -114,8 +113,8 @@ main.rs
 
 ## 향후 개선 제안
 
-1. **AVIF 입력 지원**: `image` 크레이트의 `avif-decoder` feature 활성화 + `libdav1d` 시스템 의존성 추가
-2. **`--threads` CLI 옵션**: 환경변수 외에 명시적 플래그
+1. **`--threads` CLI 옵션**: 환경변수 외에 명시적 플래그
+2. **`image` 0.25 업그레이드**: 10-bit AVIF 디코딩 지원. breaking change 가 있어 별도 작업
 3. **HEIC 입력**: iPhone 사진 변환용. `libheif` 시스템 의존성 + 외부 크레이트
 4. **설정 모듈**: 품질 프리셋, 기본값 등을 관리하는 `config.rs`
 5. **다국어 지원**: 메시지를 별도 파일로 분리

--- a/README.md
+++ b/README.md
@@ -15,31 +15,41 @@
 
 ## 🎯 지원 포맷 매트릭스
 
-| 포맷       | 입력 | 출력 | 비고                                                             |
-| ---------- | :--: | :--: | ---------------------------------------------------------------- |
-| PNG        |  ✅  |  ✅  | 무손실. 출력 시 `--quality` 무시                                 |
-| JPG / JPEG |  ✅  |  ✅  | 알파 채널 미지원 — 자동으로 RGB 변환 후 인코딩                   |
-| WebP       |  ✅  |  ✅  |                                                                  |
-| AVIF       |  ❌  |  ✅  | 입력은 `libdav1d` 시스템 의존성을 요구하므로 추후 별도 PR 로 추가 |
-| TIFF       |  ✅  |  ❌  | 입력만 지원                                                      |
-| BMP        |  ✅  |  ❌  | 입력만 지원                                                      |
-| ICO        |  ✅  |  ❌  | 입력만 지원                                                      |
+| 포맷       | 입력 | 출력 | 비고                                                                                                |
+| ---------- | :--: | :--: | --------------------------------------------------------------------------------------------------- |
+| PNG        |  ✅  |  ✅  | 무손실. 출력 시 `--quality` 무시                                                                    |
+| JPG / JPEG |  ✅  |  ✅  | 알파 채널 미지원 — 자동으로 RGB 변환 후 인코딩                                                      |
+| WebP       |  ✅  |  ✅  |                                                                                                     |
+| AVIF       |  ✅  |  ✅  | 인코딩은 8-bit 로 고정 (라운드트립 호환성). 외부 도구로 만든 10-bit AVIF 입력은 `image` 0.24 한계로 미지원 |
+| TIFF       |  ✅  |  ❌  | 입력만 지원                                                                                         |
+| BMP        |  ✅  |  ❌  | 입력만 지원                                                                                         |
+| ICO        |  ✅  |  ❌  | 입력만 지원                                                                                         |
 
 ## 📦 설치
 
 1. Rust가 설치되어 있어야 합니다. [Rust 설치 가이드](https://www.rust-lang.org/tools/install)를 참고하세요.
-2. 이 프로젝트를 클론하거나 다운로드합니다:
+2. **시스템 라이브러리 설치** — AVIF 인코딩(`rav1e`)에는 `nasm`, AVIF 디코딩(`dav1d`)에는 `libdav1d` 가 필요합니다.
 
-```bash
-git clone <repository-url>
-cd image_converter
-```
+   ```bash
+   # Ubuntu / WSL
+   sudo apt install -y nasm libdav1d-dev
 
-3. 프로젝트 디렉토리에서 빌드합니다:
+   # macOS
+   brew install nasm dav1d
+   ```
 
-```bash
-cargo build --release
-```
+3. 이 프로젝트를 클론하거나 다운로드합니다:
+
+   ```bash
+   git clone <repository-url>
+   cd image_converter
+   ```
+
+4. 프로젝트 디렉토리에서 빌드합니다:
+
+   ```bash
+   cargo build --release
+   ```
 
 ## 🚀 사용법
 
@@ -73,6 +83,9 @@ cargo build --release
 
 # 역변환: WebP → PNG (무손실, quality 무시됨)
 ./target/release/image_converter -i photo.webp -o photo.png -f png
+
+# 역변환: AVIF → PNG (8-bit AVIF 만 지원)
+./target/release/image_converter -i photo.avif -o photo.png -f png
 
 # JPEG 로 변환 (알파 채널이 있으면 자동 RGB 변환)
 ./target/release/image_converter -i icon.png -o icon.jpg -f jpeg -q 85

--- a/TESTING.md
+++ b/TESTING.md
@@ -137,7 +137,11 @@ cargo test --release
     - BMP 입력이 디코딩되어 JPEG 로 변환되는지 확인
 
 18. **`test_batch_mixed_input_formats`**
-    - PNG + WebP + TIFF + BMP 4종이 한 디렉토리에 섞여 있을 때 모두 PNG 로 일괄 변환되는지 확인 (배치 모드의 입력 화이트리스트 + 다중 디코더 결합 검증)
+    - PNG + WebP + AVIF + TIFF + BMP 5종이 한 디렉토리에 섞여 있을 때 모두 PNG 로 일괄 변환되는지 확인 (배치 모드의 입력 화이트리스트 + 다중 디코더 결합 검증)
+
+19. **`test_avif_input_to_png`**
+    - AVIF → PNG 라운드트립이 동작하는지 확인 (`avif-decoder` feature + `dav1d` 디코딩, 8-bit AVIF 인코딩)
+    - 출력 파일이 PNG 매직 바이트로 시작하는지 검증
 
 ## 테스트 매크로
 
@@ -197,7 +201,7 @@ fn test_new_feature() {
 
 ## 테스트 커버리지
 
-현재 테스트는 다음 영역을 커버합니다 (총 18개):
+현재 테스트는 다음 영역을 커버합니다 (총 19개):
 - ✅ 파일 크기 포맷팅
 - ✅ WebP / AVIF 단일 변환
 - ✅ 품질 파라미터 검증
@@ -205,12 +209,12 @@ fn test_new_feature() {
 - ✅ 비이미지 파일 자동 스킵
 - ✅ 빈 디렉토리 처리
 - ✅ 에러 처리 (지원하지 않는 형식, 존재하지 않는 파일)
-- ✅ PNG / JPEG 출력 (WebP → PNG 역변환, PNG → JPEG, jpg 별칭)
-- ✅ TIFF / BMP 입력 디코딩
-- ✅ 혼합 입력 포맷 일괄 변환 (PNG + WebP + TIFF + BMP → PNG)
+- ✅ PNG / JPEG 출력 (WebP → PNG 역변환, AVIF → PNG 역변환, PNG → JPEG, jpg 별칭)
+- ✅ TIFF / BMP / AVIF 입력 디코딩
+- ✅ 혼합 입력 포맷 일괄 변환 (PNG + WebP + AVIF + TIFF + BMP → PNG)
 
 향후 추가할 수 있는 테스트:
-- AVIF 입력 디코딩 (`libdav1d` 의존성 추가 후)
+- 10-bit AVIF 입력 디코딩 (`image` 0.25 업그레이드 후)
 - JPG/JPEG 단일 입력 명시 케이스 (현재는 혼합 배치로 간접 커버)
 - 일괄 변환 중 일부 파일이 손상되어 실패할 때의 동작
 - 대용량 이미지 처리

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -19,7 +19,6 @@ pub struct BatchSummary {
 }
 
 /// 입력 파일이 지원하는 이미지 확장자인지 확인
-/// AVIF 입력은 dav1d 시스템 의존성을 요구해서 별도 PR 로 분리됨
 fn is_supported_image(path: &Path) -> bool {
     matches!(
         path.extension()
@@ -27,7 +26,7 @@ fn is_supported_image(path: &Path) -> bool {
             .map(|s| s.to_lowercase())
             .as_deref(),
         Some(
-            "png" | "jpg" | "jpeg" | "webp" | "tiff" | "tif" | "bmp" | "ico"
+            "png" | "jpg" | "jpeg" | "webp" | "avif" | "tiff" | "tif" | "bmp" | "ico"
         )
     )
 }
@@ -108,7 +107,7 @@ pub fn convert_directory(
 
     if files.is_empty() {
         println!(
-            "\n{} 변환 가능한 이미지(.png/.jpg/.jpeg/.webp/.tiff/.bmp/.ico)가 없습니다.",
+            "\n{} 변환 가능한 이미지(.png/.jpg/.jpeg/.webp/.avif/.tiff/.bmp/.ico)가 없습니다.",
             "⚠️".bright_yellow()
         );
         return Ok(BatchSummary {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,7 +1,7 @@
 use colored::*;
 use image::{DynamicImage, GenericImageView, ImageOutputFormat};
 use indicatif::{ProgressBar, ProgressStyle};
-use ravif::{Encoder as AvifEncoder, Img, RGBA8};
+use ravif::{BitDepth, Encoder as AvifEncoder, Img, RGBA8};
 use std::fs;
 use std::io::Cursor;
 use webp::Encoder as WebpEncoder;
@@ -33,7 +33,12 @@ fn encode_to(img: &DynamicImage, format: &str, quality: f32) -> Result<Vec<u8>> 
                 .pixels()
                 .map(|p| RGBA8::new(p[0], p[1], p[2], p[3]))
                 .collect();
-            let encoder = AvifEncoder::new().with_quality(quality).with_speed(4);
+            // 8-bit depth 로 강제 — image 0.24 의 AVIF 디코더가 8-bit 만 지원하므로
+            // 라운드트립(역변환) 호환성을 위해 ravif default(10-bit) 대신 8-bit 사용
+            let encoder = AvifEncoder::new()
+                .with_quality(quality)
+                .with_speed(4)
+                .with_bit_depth(BitDepth::Eight);
             let res = encoder.encode_rgba(Img::new(&pixels, width as usize, height as usize))?;
             Ok(res.avif_file)
         }

--- a/src/tests/integration_tests.rs
+++ b/src/tests/integration_tests.rs
@@ -485,7 +485,7 @@ fn test_bmp_input_to_jpeg() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_batch_mixed_input_formats() -> Result<(), Box<dyn std::error::Error>> {
     test_description!("일괄 변환에서 다양한 입력 포맷 혼합 테스트");
-    test_step!("PNG + WebP + TIFF + BMP 가 한 디렉토리에 있을 때 모두 PNG 로 변환되는지");
+    test_step!("PNG + WebP + AVIF + TIFF + BMP 가 한 디렉토리에 있을 때 모두 PNG 로 변환되는지");
 
     let temp_dir = TempDir::new()?;
     let input_dir = temp_dir.path().join("mixed_input");
@@ -497,7 +497,7 @@ fn test_batch_mixed_input_formats() -> Result<(), Box<dyn std::error::Error>> {
     create_test_image(input_dir.join("b.tiff").to_str().unwrap(), 50, 50)?;
     create_test_image(input_dir.join("c.bmp").to_str().unwrap(), 50, 50)?;
 
-    // WebP 는 별도 webp 크레이트로 인코딩 — 임시 PNG 를 거쳐 생성
+    // WebP / AVIF 는 별도 인코더라 PNG 시드를 거쳐 생성
     let temp_png = temp_dir.path().join("temp_seed.png");
     create_test_image(temp_png.to_str().unwrap(), 50, 50)?;
     convert_image_silent(
@@ -506,7 +506,13 @@ fn test_batch_mixed_input_formats() -> Result<(), Box<dyn std::error::Error>> {
         "webp",
         90.0,
     )?;
-    test_success!("혼합 입력 4개 (PNG/TIFF/BMP/WebP) 준비 완료");
+    convert_image_silent(
+        temp_png.to_str().unwrap(),
+        input_dir.join("e.avif").to_str().unwrap(),
+        "avif",
+        85.0,
+    )?;
+    test_success!("혼합 입력 5개 (PNG/TIFF/BMP/WebP/AVIF) 준비 완료");
 
     let summary = convert_directory(
         input_dir.to_str().unwrap(),
@@ -516,13 +522,55 @@ fn test_batch_mixed_input_formats() -> Result<(), Box<dyn std::error::Error>> {
         false,
     )?;
 
-    assert_eq!(summary.total_files, 4, "4개 파일이 처리 대상");
-    assert_eq!(summary.succeeded, 4, "4개 모두 성공");
+    assert_eq!(summary.total_files, 5, "5개 파일이 처리 대상");
+    assert_eq!(summary.succeeded, 5, "5개 모두 성공");
     assert!(output_dir.join("a.png").exists());
     assert!(output_dir.join("b.png").exists());
     assert!(output_dir.join("c.png").exists());
     assert!(output_dir.join("d.png").exists());
-    test_success!("4종 입력 포맷 모두 PNG 로 변환 성공");
+    assert!(output_dir.join("e.png").exists());
+    test_success!("5종 입력 포맷 모두 PNG 로 변환 성공");
+
+    Ok(())
+}
+
+#[test]
+fn test_avif_input_to_png() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("AVIF → PNG 역변환 테스트");
+    test_step!("AVIF 파일을 PNG 로 디코딩 (avif-decoder feature + dav1d)");
+
+    let temp_dir = TempDir::new()?;
+    let png_seed = temp_dir.path().join("seed.png");
+    let avif_path = temp_dir.path().join("intermediate.avif");
+    let restored_path = temp_dir.path().join("restored.png");
+
+    // 1) PNG 시드 → 2) AVIF 인코딩 → 3) AVIF 입력을 다시 PNG 로 디코딩
+    create_test_image(png_seed.to_str().unwrap(), 60, 60)?;
+    convert_image_silent(
+        png_seed.to_str().unwrap(),
+        avif_path.to_str().unwrap(),
+        "avif",
+        85.0,
+    )?;
+    test_success!("AVIF 중간 파일 생성");
+
+    convert_image_silent(
+        avif_path.to_str().unwrap(),
+        restored_path.to_str().unwrap(),
+        "png",
+        90.0,
+    )?;
+
+    assert!(restored_path.exists(), "복원된 PNG 파일이 생성되어야 함");
+
+    // PNG 시그니처 검증
+    let bytes = fs::read(&restored_path)?;
+    assert_eq!(
+        &bytes[0..4],
+        &[0x89, 0x50, 0x4E, 0x47],
+        "PNG 매직 바이트 확인"
+    );
+    test_success!("AVIF → PNG 역변환 + 시그니처 확인");
 
     Ok(())
 }


### PR DESCRIPTION
- `Cargo.toml` — `image = { version = "0.24.2", features = ["avif-decoder"] }` 로 변경. `mp4parse` / `dcv-color-primitives` / `dav1d-sys` / `dav1d` 자동 추가
- 시스템 의존성 추가: `libdav1d-dev` (apt) / `dav1d` (brew). 빌드 시 `pkg-config` 로 동적 링크
- `src/batch.rs` — `is_supported_image()` 화이트리스트에 `"avif"` 한 단어 추가, 빈 디렉토리 안내 메시지의 확장자 목록도 갱신
- `src/converter.rs` — AVIF 인코딩에 `.with_bit_depth(BitDepth::Eight)` 강제

호환성 이슈 + 결정:

- `ravif` default 인코딩이 10-bit AVIF 를 만들지만 `image` 0.24 의 AVIF 디코더는 8-bit 만 지원해서 라운드트립이 깨졌음 (`Only 8 bit depth is supported but was 10`)
- 인코딩을 8-bit 로 강제 (`with_bit_depth(BitDepth::Eight)`) 해서 우리가 만든 AVIF 를 우리가 다시 디코딩 가능하게 함
- 외부 도구로 만든 10-bit AVIF 입력은 여전히 미지원 — `image` 0.25 업그레이드를 향후 후보로 정리
- `with_depth(Some(8))` 은 deprecated, `with_bit_depth(BitDepth::Eight)` 가 신 API

회귀 + 신규 검증:

- 통합 테스트 1개 추가 + 1개 갱신 (총 18 → 19, 모두 통과)
  - 신규 `test_avif_input_to_png` — PNG 시드 → AVIF 인코딩 → AVIF 디코딩 → PNG 라운드트립 + 시그니처 검증
  - 갱신 `test_batch_mixed_input_formats` — 입력 포맷 4종 (PNG/WebP/TIFF/BMP) → 5종 (+ AVIF)
- `cargo build --release` 통과
- 기존 17개 테스트 회귀 없음

문서 갱신:

- `README.md` — 매트릭스 표 AVIF 입력 ❌ → ✅, 비고에 8-bit 한계 명시. 설치 섹션에 `libdav1d-dev` / `dav1d` 추가, 명령줄 예제에 AVIF → PNG 역변환 추가
- `CLAUDE.md` — 프로젝트 개요 갱신 (AVIF 8-bit 명시), 시스템 요구사항에 `libdav1d-dev` 추가, 향후 후보에 `image` 0.25 업그레이드 추가
- `PROJECT_STRUCTURE.md` — `encode_to()` AVIF 분기 코멘트, `is_supported_image()` 화이트리스트 갱신
- `TESTING.md` — 새 테스트 + 5종 mixed 갱신, 커버리지 18 → 19
- `MEMORY.md` — 작업 로그, 8-bit 강제 결정 기록, 진행 항목, 환경 메모(dav1d) 갱신