### PR TITLE
test: JPG/JPEG 단일 입력 회귀 테스트 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ src/
 ├── interactive.rs     # 대화형 모드 (단일/디렉토리 선택 → 출력 포맷 → 옵션 → 실행).
 │                      # PNG 출력 시 quality 단계는 자동 스킵
 ├── utils.rs           # format_file_size 등 헬퍼
-└── tests/             # 단위 + 통합 테스트 (총 20개)
+└── tests/             # 단위 + 통합 테스트 (총 23개)
 ```
 
 세부 책임은 `PROJECT_STRUCTURE.md` 참고.
@@ -114,11 +114,10 @@ Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 (우선순위 추정 순)
 
 1. **`image` 0.25 업그레이드** — 0.24 의 AVIF 디코더가 8-bit 만 지원하는 한계 해소 (10-bit AVIF 입력 지원). breaking change 가 있어 별도 작업
-2. **JPG/JPEG 단일 입력 회귀 테스트** — 현재는 혼합 배치 / 다른 포맷 출력으로만 간접 커버. 명시적 단일 케이스
-3. **HEIC 입력** — iPhone 사진 변환용. `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트 도입 필요
-4. **대화형 모드에서 `--threads` 질문** — 현재는 CLI 플래그로만 노출, 대화형 모드는 default 사용
-5. **대화형 모드 테스트** — 현재 미커버
-6. **다국어/메시지 분리** — 메시지를 별도 파일/리소스로
+2. **HEIC 입력** — iPhone 사진 변환용. `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트 도입 필요
+3. **대화형 모드에서 `--threads` 질문** — 현재는 CLI 플래그로만 노출, 대화형 모드는 default 사용
+4. **대화형 모드 테스트** — 현재 미커버
+5. **다국어/메시지 분리** — 메시지를 별도 파일/리소스로
 
 ## 관련 문서
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,6 +12,16 @@
 
 ## 최근 작업 로그
 
+### 2026-04-30 — `test: JPG/JPEG 단일 입력 회귀 테스트 추가` (PR 진행 중)
+
+- `src/tests/integration_tests.rs` — 통합 테스트 3개 추가 (총 20 → 23, 모두 통과):
+  - `test_jpeg_input_to_webp` — JPEG 시드를 만든 뒤 WebP 로 변환. RIFF/WEBP 시그니처 검증
+  - `test_jpeg_input_to_png` — JPEG → PNG. PNG 매직 바이트(`89 50 4E 47`) 검증
+  - `test_jpg_extension_input` — `.jpg` 확장자 입력도 JPEG 디코더에 인식되는지 확인 (입력 측 별칭 회귀 방지)
+- 시드 생성: `create_test_image()` 가 `ImageBuffer::save(path)` 로 확장자 자동 감지하므로 `.jpeg`/`.jpg` 로 저장하면 image 크레이트의 JPEG 인코더가 직접 호출됨 (별도 헬퍼 불필요)
+- 기존 회귀 테스트 (`test_jpeg_output_from_png_input`, `test_jpg_alias_for_jpeg`, `test_batch_mixed_input_formats`) 가 출력 측 / 혼합 배치만 커버하던 공백을 채움
+- TESTING.md / CLAUDE.md 갱신 — 테스트 개수 20 → 23, 향후 후보에서 "JPG/JPEG 단일 입력 명시 케이스" 제거
+
 ### 2026-04-30 — `feat: --threads CLI 옵션 추가` (PR 진행 중)
 
 - `src/main.rs` — `Cli` 에 `threads: Option<usize>` 필드 (`-t/--threads <N>`) 추가. 단일 변환에는 영향 없고 디렉토리 모드일 때만 `convert_directory` 에 전달. 버전 `2.3` → `2.4`
@@ -135,11 +145,12 @@
 - [x] **다중 입출력 포맷 지원 (A안)** — 완료. PNG/JPG/JPEG 출력 + WebP/TIFF/BMP/ICO 입력 추가. 18 테스트 통과.
 - [x] **AVIF 입력 (B안)** — 완료. `avif-decoder` feature 활성화 + `libdav1d-dev` 의존성 추가. 라운드트립을 위해 ravif 인코딩을 8-bit 로 강제. 19 테스트 통과.
 - [x] **`--threads` CLI 옵션** — 완료. `convert_directory` 가 `Option<usize>` 를 받아 local pool 로 scoped 실행. CLI 우선, 환경변수 fallback. 20 테스트 통과.
+- [x] **JPG/JPEG 단일 입력 명시 회귀 테스트** — 완료. 통합 테스트 3개 추가 (jpeg→webp, jpeg→png, .jpg 확장자 입력). 23 테스트 통과.
 - [ ] **`image` 0.25 업그레이드** — 10-bit AVIF 디코딩 지원. breaking change 가 있어 별도 작업. 업그레이드 후 ravif 의 8-bit 강제도 풀어줄 수 있음
-- [ ] **JPG/JPEG 단일 입력 명시 회귀 테스트** — 다중 포맷 PR 에서 혼합 배치로 간접 커버. 명시적 단일 케이스는 별도.
 - [ ] **HEIC 입력** — `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트. 부담 큼.
-- [ ] **대화형 모드에서 `--threads` 질문 추가** — 현재는 CLI 플래그로만 노출.
-- [ ] **대화형 모드 테스트** — `dialoguer` 입력 모킹이 까다로워 우선순위 낮음.
+- [ ] **CLI 인자 검증 강화** — `--threads 0` 거부, `--quality` 1-100 범위 검증. clap `value_parser!.range(...)` 적용.
+- [ ] **대화형 모드 리팩토링 + 단위 테스트 + `--threads` 질문 추가** — `validate_with` 클로저와 default 출력 경로 빌더를 순수 함수로 분리해서 단위 테스트 가능하게 만들고, 그 김에 디렉토리 모드에 threads 질문 단계 추가. dialoguer 자체 모킹은 비용이 커서 보류.
+- [ ] **대화형 모드 통합 테스트** — `dialoguer` 의 `Select` 가 PTY 필요해서 `rexpect` 등 도입 부담. 우선순위 낮음 (위 리팩토링으로 단위 테스트는 우회 커버).
 
 ## 환경 메모
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -147,6 +147,17 @@ cargo test --release
     - `convert_directory()` 의 `threads: Option<usize>` 인자 검증
     - `None` (기본) 과 `Some(1)` (단일 스레드) 두 모드에서 같은 입력에 대해 같은 성공 개수가 나오는지 확인 (스레드 수에 결과가 영향받지 않아야 함)
 
+21. **`test_jpeg_input_to_webp`**
+    - JPEG 입력을 WebP 로 변환하는 명시적 단일 케이스
+    - 출력 파일이 RIFF/WEBP 시그니처로 시작하는지 검증
+
+22. **`test_jpeg_input_to_png`**
+    - JPEG 입력을 PNG 로 변환 (JPEG 디코더 + PNG 인코더 결합)
+    - 출력이 PNG 매직 바이트(`89 50 4E 47`) 로 시작하는지 검증
+
+23. **`test_jpg_extension_input`**
+    - 입력 측 `.jpg` 확장자도 JPEG 디코더로 정상 인식되는지 확인 (`.jpg`/`.jpeg` 양쪽 별칭 회귀 방지)
+
 ## 테스트 매크로
 
 ### `test_description!`
@@ -205,7 +216,7 @@ fn test_new_feature() {
 
 ## 테스트 커버리지
 
-현재 테스트는 다음 영역을 커버합니다 (총 20개):
+현재 테스트는 다음 영역을 커버합니다 (총 23개):
 - ✅ 파일 크기 포맷팅
 - ✅ WebP / AVIF 단일 변환
 - ✅ 품질 파라미터 검증
@@ -217,10 +228,10 @@ fn test_new_feature() {
 - ✅ TIFF / BMP / AVIF 입력 디코딩
 - ✅ 혼합 입력 포맷 일괄 변환 (PNG + WebP + AVIF + TIFF + BMP → PNG)
 - ✅ 명시적 스레드 수 옵션 (`threads=None` vs `threads=Some(1)` 결과 일관성)
+- ✅ JPG/JPEG 단일 입력 (jpeg→webp, jpeg→png, .jpg 확장자 별칭)
 
 향후 추가할 수 있는 테스트:
 - 10-bit AVIF 입력 디코딩 (`image` 0.25 업그레이드 후)
-- JPG/JPEG 단일 입력 명시 케이스 (현재는 혼합 배치로 간접 커버)
 - 일괄 변환 중 일부 파일이 손상되어 실패할 때의 동작
 - 대용량 이미지 처리
 - 메모리 사용량 테스트

--- a/src/tests/integration_tests.rs
+++ b/src/tests/integration_tests.rs
@@ -631,3 +631,91 @@ fn test_avif_input_to_png() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_jpeg_input_to_webp() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("JPEG 입력을 WebP 로 변환");
+    test_step!("JPEG 디코더 + WebP 인코더 결합 검증 (단일 입력 명시 케이스)");
+
+    let temp_dir = TempDir::new()?;
+    let jpeg_path = temp_dir.path().join("seed.jpeg");
+    let webp_path = temp_dir.path().join("out.webp");
+
+    // ImageBuffer::save 가 .jpeg 확장자로 JPEG 인코더 호출
+    create_test_image(jpeg_path.to_str().unwrap(), 80, 80)?;
+    test_success!("JPEG 시드 파일 생성");
+
+    convert_image_silent(
+        jpeg_path.to_str().unwrap(),
+        webp_path.to_str().unwrap(),
+        "webp",
+        85.0,
+    )?;
+
+    assert!(webp_path.exists(), "WebP 파일이 생성되어야 함");
+
+    // WebP 시그니처 검증 (RIFF...WEBP)
+    let bytes = fs::read(&webp_path)?;
+    assert_eq!(&bytes[0..4], b"RIFF", "RIFF 매직 바이트 확인");
+    assert_eq!(&bytes[8..12], b"WEBP", "WEBP 시그니처 확인");
+    test_success!("JPEG → WebP 변환 + 시그니처 확인");
+
+    Ok(())
+}
+
+#[test]
+fn test_jpeg_input_to_png() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("JPEG 입력을 PNG 로 변환");
+    test_step!("JPEG 디코더 + PNG 인코더 결합 검증");
+
+    let temp_dir = TempDir::new()?;
+    let jpeg_path = temp_dir.path().join("seed.jpeg");
+    let png_path = temp_dir.path().join("out.png");
+
+    create_test_image(jpeg_path.to_str().unwrap(), 70, 70)?;
+
+    convert_image_silent(
+        jpeg_path.to_str().unwrap(),
+        png_path.to_str().unwrap(),
+        "png",
+        100.0,
+    )?;
+
+    assert!(png_path.exists(), "PNG 파일이 생성되어야 함");
+
+    let bytes = fs::read(&png_path)?;
+    assert_eq!(
+        &bytes[0..4],
+        &[0x89, 0x50, 0x4E, 0x47],
+        "PNG 매직 바이트 확인"
+    );
+    test_success!("JPEG → PNG 변환 + 시그니처 확인");
+
+    Ok(())
+}
+
+#[test]
+fn test_jpg_extension_input() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("'.jpg' 확장자 입력이 JPEG 디코더로 인식되는지 테스트");
+    test_step!("입력 측 jpg/jpeg 별칭 동작 확인");
+
+    let temp_dir = TempDir::new()?;
+    let jpg_path = temp_dir.path().join("seed.jpg");
+    let webp_path = temp_dir.path().join("out.webp");
+
+    // .jpg 확장자도 JPEG 인코더로 저장됨
+    create_test_image(jpg_path.to_str().unwrap(), 60, 60)?;
+    test_success!("'.jpg' 시드 파일 생성");
+
+    convert_image_silent(
+        jpg_path.to_str().unwrap(),
+        webp_path.to_str().unwrap(),
+        "webp",
+        85.0,
+    )?;
+
+    assert!(webp_path.exists(), "'.jpg' 입력도 정상 디코딩되어야 함");
+    test_success!("'.jpg' 확장자 입력 디코딩 성공");
+
+    Ok(())
+}


### PR DESCRIPTION
- `test_jpeg_input_to_webp` / `test_jpeg_input_to_png` / `test_jpg_extension_input` 통합 테스트 3개 추가 (총 20 → 23, 모두 통과)
- 기존엔 혼합 배치 (`test_batch_mixed_input_formats`) 와 출력 측 (`test_jpeg_output_from_png_input`, `test_jpg_alias_for_jpeg`) 으로만 간접 커버되던 JPEG 단일 입력 공백 해소
- 시드 생성은 `ImageBuffer::save("path.jpeg")` 가 image 크레이트 JPEG 인코더로 자동 라우팅 — 별도 헬퍼 불필요
- TESTING.md / CLAUDE.md / MEMORY.md 갱신