### PR TITLE
fix: CLI 인자 검증 강화 (--threads, --quality)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ src/
 ├── interactive.rs     # 대화형 모드 (단일/디렉토리 선택 → 출력 포맷 → 옵션 → 실행).
 │                      # PNG 출력 시 quality 단계는 자동 스킵
 ├── utils.rs           # format_file_size 등 헬퍼
-└── tests/             # 단위 + 통합 테스트 (총 23개)
+└── tests/             # 단위 + 통합 테스트 (총 29개)
 ```
 
 세부 책임은 `PROJECT_STRUCTURE.md` 참고.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,6 +12,17 @@
 
 ## 최근 작업 로그
 
+### 2026-04-30 — `fix: CLI 인자 검증 강화 (--threads, --quality)` (PR 진행 중)
+
+- `src/main.rs` — `parse_quality(s) -> Result<f32, String>` (1.0~100.0 범위 검증), `parse_threads(s) -> Result<usize, String>` (1 이상 정수 검증) 두 사용자 정의 파서 추가. clap `#[arg(... value_parser = parse_quality)]` / `value_parser = parse_threads` 로 연결
+- 한국어 에러 메시지: `"품질은 1.0~100.0 범위여야 합니다 (입력: {q})"`, `"스레드 수는 1 이상이어야 합니다"`, `"'{s}' 는 유효한 숫자가 아닙니다"` — clap 의 영어 wrapper 안에 그대로 노출
+- 기존엔 `--threads 0` 이 `rayon::ThreadPoolBuilder::new().num_threads(0).build()` 단계에서 panic 가능, `--quality 200` 은 인코더 분기의 `clamp(1, 100)` 에 의해 silent 100 으로 처리되던 사각지대 해소
+- `src/main.rs` 끝에 `#[cfg(test)] mod tests` 추가 — 단위 테스트 6개 (`parse_quality_*` 3개 + `parse_threads_*` 3개): 정상 범위 통과, 범위 외 거부, 비숫자/음수 거부, 한국어 에러 메시지 포함 확인
+- `--threads` doc 주석 / README.md `-t` 옵션 설명에 "1 이상" 명시
+- 23 통합 + 6 단위 = 29 테스트 모두 통과
+- **clap 한계**: `-q -10` 같이 음수 값은 clap 이 `-1` 을 short 옵션으로 해석해서 우리 검증 도달 전에 "unexpected argument" 에러가 남. `--quality=-10` 형태나 `-q 0.5` 로는 정상 차단. 이 한계는 일반적인 clap 동작이라 별도 워크어라운드 안 함
+- TESTING.md / CLAUDE.md / README.md / MEMORY.md 갱신
+
 ### 2026-04-30 — `test: JPG/JPEG 단일 입력 회귀 테스트 추가` (PR 진행 중)
 
 - `src/tests/integration_tests.rs` — 통합 테스트 3개 추가 (총 20 → 23, 모두 통과):
@@ -136,6 +147,8 @@
 - **`encode_to()` 헬퍼 분리** — 단일 변환의 UI 포함 버전과 조용한 버전, 그리고 일괄 변환에서 호출되는 inner 까지 세 곳이 동일 인코딩 로직을 쓰는 상황. 헬퍼로 분리하여 한 군데에서만 유지.
 - **`convert_image_silent` 의 반환 타입을 `()` → `ConvertStats`** — 일괄 모드의 합계 통계 계산을 위해. 기존 테스트는 `?` 로만 결과를 처리해서 시그니처 변경에 영향 없음.
 - **bin/lib 중복 컴파일 제거** — `main.rs` 가 `mod converter;` 등으로 모듈을 직접 포함하면 lib 과 bin 양쪽에서 같은 코드가 컴파일되고 `convert_image_silent` 가 bin 측에서 dead_code 경고. `main.rs` 를 `image_converter::*` 로 import 하도록 변경하여 해결.
+- **CLI 인자 검증은 사용자 정의 파서로 통일** — clap v4 의 `clap::value_parser!().range(..)` 는 정수 (`u16`/`usize` 등) 만 직접 지원하고 `f32`/`f64` 는 안 됨. quality (float) 와 threads (usize) 두 인자가 있어서 한쪽만 빌트인 range 를 쓰면 일관성이 깨지므로, 양쪽 다 `fn parse_quality(&str) -> Result<f32, String>` / `fn parse_threads(&str) -> Result<usize, String>` 사용자 정의 파서로 통일. 부수 효과로 한국어 에러 메시지 (`"품질은 1.0~100.0 범위여야 합니다"`) 를 직접 작성 가능 — clap 의 영어 wrapper (`"invalid value '0' for ..."`) 안에 우리 사유가 그대로 노출됨.
+- **음수 인자 (`-q -10`) 는 clap 한계로 별도 워크어라운드 안 함** — clap 은 `-` 시작 토큰을 short option 으로 해석해서 `-1` 이 unknown flag 로 거부됨. `allow_negative_numbers` attribute 를 켜면 우회 가능하지만 사용자가 음수 quality 를 의도적으로 넣는 경우는 거의 없고, `--quality=-10` / `-q 0.5` 형태로는 우리 검증이 정상 차단하므로 단순함을 위해 보류.
 
 ## 진행 중 / 대기
 
@@ -146,9 +159,9 @@
 - [x] **AVIF 입력 (B안)** — 완료. `avif-decoder` feature 활성화 + `libdav1d-dev` 의존성 추가. 라운드트립을 위해 ravif 인코딩을 8-bit 로 강제. 19 테스트 통과.
 - [x] **`--threads` CLI 옵션** — 완료. `convert_directory` 가 `Option<usize>` 를 받아 local pool 로 scoped 실행. CLI 우선, 환경변수 fallback. 20 테스트 통과.
 - [x] **JPG/JPEG 단일 입력 명시 회귀 테스트** — 완료. 통합 테스트 3개 추가 (jpeg→webp, jpeg→png, .jpg 확장자 입력). 23 테스트 통과.
+- [x] **CLI 인자 검증 강화** — 완료. `parse_quality` / `parse_threads` 사용자 정의 파서 + 단위 테스트 6개. `--threads 0` 한국어 메시지로 차단, `--quality 200/0.5/abc` 거부. 29 테스트 통과.
 - [ ] **`image` 0.25 업그레이드** — 10-bit AVIF 디코딩 지원. breaking change 가 있어 별도 작업. 업그레이드 후 ravif 의 8-bit 강제도 풀어줄 수 있음
 - [ ] **HEIC 입력** — `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트. 부담 큼.
-- [ ] **CLI 인자 검증 강화** — `--threads 0` 거부, `--quality` 1-100 범위 검증. clap `value_parser!.range(...)` 적용.
 - [ ] **대화형 모드 리팩토링 + 단위 테스트 + `--threads` 질문 추가** — `validate_with` 클로저와 default 출력 경로 빌더를 순수 함수로 분리해서 단위 테스트 가능하게 만들고, 그 김에 디렉토리 모드에 threads 질문 단계 추가. dialoguer 자체 모킹은 비용이 커서 보류.
 - [ ] **대화형 모드 통합 테스트** — `dialoguer` 의 `Select` 가 PTY 필요해서 `rexpect` 등 도입 부담. 우선순위 낮음 (위 리팩토링으로 단위 테스트는 우회 커버).
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ RAYON_NUM_THREADS=4 ./target/release/image_converter -i photos -o photos_webp -f
 - `-f, --format <FORMAT>`: 출력 형식 (`png`, `jpg`, `jpeg`, `webp`, `avif`)
 - `-q, --quality <QUALITY>`: 변환 품질 1-100 (기본값: 90, **PNG 출력 시 무손실이라 무시됨**)
 - `-r, --recursive`: 디렉토리 입력 시 하위 폴더까지 재귀 변환
-- `-t, --threads <N>`: 디렉토리 모드에서 사용할 스레드 수 (미지정 시 `RAYON_NUM_THREADS` 또는 CPU 코어 수). 단일 파일 변환에는 영향 없음
+- `-t, --threads <N>`: 디렉토리 모드에서 사용할 스레드 수 (1 이상, 미지정 시 `RAYON_NUM_THREADS` 또는 CPU 코어 수). 단일 파일 변환에는 영향 없음
 
 ## 💡 예제 출력
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,6 +8,7 @@
 
 ```
 src/
+  main.rs         # CLI 인자 파서 단위 테스트 (#[cfg(test)] mod tests)
   lib.rs          # 테스트용 함수들
   tests/
     mod.rs        # 테스트 모듈 선언
@@ -158,6 +159,26 @@ cargo test --release
 23. **`test_jpg_extension_input`**
     - 입력 측 `.jpg` 확장자도 JPEG 디코더로 정상 인식되는지 확인 (`.jpg`/`.jpeg` 양쪽 별칭 회귀 방지)
 
+### 🛠️ CLI 인자 파서 단위 테스트 (`src/main.rs`)
+
+24. **`parse_quality_accepts_valid_range`**
+    - `--quality` 가 1.0 / 50.5 / 100.0 같은 정상 범위 값을 통과시키는지 확인
+
+25. **`parse_quality_rejects_out_of_range`**
+    - 0, 0.99, 100.01, -10, 200 같은 범위 외 값이 거부되는지 확인
+
+26. **`parse_quality_rejects_non_numeric`**
+    - `"abc"` 같은 비숫자 입력이 한국어 에러 메시지("유효한 숫자가 아닙니다") 와 함께 거부되는지 확인
+
+27. **`parse_threads_accepts_positive`**
+    - `--threads` 가 1, 16 같은 양의 정수를 통과시키는지 확인
+
+28. **`parse_threads_rejects_zero`**
+    - 0 이 거부되고 한국어 에러 메시지("1 이상") 가 포함되는지 확인 (rayon 풀 빌드 단계 panic 방지)
+
+29. **`parse_threads_rejects_non_numeric`**
+    - 비숫자(`"abc"`) 와 음수(`"-1"`) 입력 거부 확인
+
 ## 테스트 매크로
 
 ### `test_description!`
@@ -216,7 +237,7 @@ fn test_new_feature() {
 
 ## 테스트 커버리지
 
-현재 테스트는 다음 영역을 커버합니다 (총 23개):
+현재 테스트는 다음 영역을 커버합니다 (총 29개):
 - ✅ 파일 크기 포맷팅
 - ✅ WebP / AVIF 단일 변환
 - ✅ 품질 파라미터 검증
@@ -229,6 +250,7 @@ fn test_new_feature() {
 - ✅ 혼합 입력 포맷 일괄 변환 (PNG + WebP + AVIF + TIFF + BMP → PNG)
 - ✅ 명시적 스레드 수 옵션 (`threads=None` vs `threads=Some(1)` 결과 일관성)
 - ✅ JPG/JPEG 단일 입력 (jpeg→webp, jpeg→png, .jpg 확장자 별칭)
+- ✅ CLI 인자 파서 (`--quality` 1.0~100.0 범위, `--threads` ≥ 1 검증, 비숫자/범위 외 거부)
 
 향후 추가할 수 있는 테스트:
 - 10-bit AVIF 입력 디코딩 (`image` 0.25 업그레이드 후)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,26 @@ use std::path::Path;
 
 use image_converter::{convert_directory, convert_image, interactive::interactive_mode};
 
+fn parse_quality(s: &str) -> Result<f32, String> {
+    let q: f32 = s
+        .parse()
+        .map_err(|_| format!("'{s}' 는 유효한 숫자가 아닙니다"))?;
+    if !(1.0..=100.0).contains(&q) {
+        return Err(format!("품질은 1.0~100.0 범위여야 합니다 (입력: {q})"));
+    }
+    Ok(q)
+}
+
+fn parse_threads(s: &str) -> Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("'{s}' 는 유효한 정수가 아닙니다"))?;
+    if n == 0 {
+        return Err("스레드 수는 1 이상이어야 합니다".into());
+    }
+    Ok(n)
+}
+
 /// PNG/JPG/JPEG/WebP/AVIF/TIFF/BMP/ICO 이미지를 PNG/JPG/WebP/AVIF 로 변환합니다 (단일 파일 + 디렉토리 일괄)
 #[derive(Parser, Debug)]
 #[command(name = "image_converter", version = "2.4", about, long_about = None)]
@@ -25,15 +45,15 @@ struct Cli {
     format: Option<String>,
 
     /// 변환 품질 1-100 (PNG 는 무손실이라 무시됨, 기본값: 90)
-    #[arg(short, long, default_value_t = 90.0)]
+    #[arg(short, long, default_value_t = 90.0, value_parser = parse_quality)]
     quality: f32,
 
     /// 디렉토리 입력 시 하위 폴더까지 재귀 변환
     #[arg(short, long)]
     recursive: bool,
 
-    /// 디렉토리 모드에서 사용할 스레드 수 (미지정 시 RAYON_NUM_THREADS 또는 CPU 코어 수)
-    #[arg(short, long, value_name = "N")]
+    /// 디렉토리 모드에서 사용할 스레드 수 (1 이상, 미지정 시 RAYON_NUM_THREADS 또는 CPU 코어 수)
+    #[arg(short, long, value_name = "N", value_parser = parse_threads)]
     threads: Option<usize>,
 }
 
@@ -65,5 +85,50 @@ fn main() {
     if let Err(e) = result {
         eprintln!("{} 오류: {}", "❌".bright_red(), e);
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_quality_accepts_valid_range() {
+        assert_eq!(parse_quality("1").unwrap(), 1.0);
+        assert_eq!(parse_quality("50.5").unwrap(), 50.5);
+        assert_eq!(parse_quality("100").unwrap(), 100.0);
+    }
+
+    #[test]
+    fn parse_quality_rejects_out_of_range() {
+        assert!(parse_quality("0").is_err());
+        assert!(parse_quality("0.99").is_err());
+        assert!(parse_quality("100.01").is_err());
+        assert!(parse_quality("-10").is_err());
+        assert!(parse_quality("200").is_err());
+    }
+
+    #[test]
+    fn parse_quality_rejects_non_numeric() {
+        let err = parse_quality("abc").unwrap_err();
+        assert!(err.contains("유효한 숫자가 아닙니다"));
+    }
+
+    #[test]
+    fn parse_threads_accepts_positive() {
+        assert_eq!(parse_threads("1").unwrap(), 1);
+        assert_eq!(parse_threads("16").unwrap(), 16);
+    }
+
+    #[test]
+    fn parse_threads_rejects_zero() {
+        let err = parse_threads("0").unwrap_err();
+        assert!(err.contains("1 이상"));
+    }
+
+    #[test]
+    fn parse_threads_rejects_non_numeric() {
+        assert!(parse_threads("abc").is_err());
+        assert!(parse_threads("-1").is_err());
     }
 }


### PR DESCRIPTION
- `--threads 0` 입력이 rayon 풀 빌드 단계에서 panic 가능했던 사각지대를 `parse_threads` 사용자 정의 파서로 차단 (한국어 메시지 "스레드 수는 1 이상이어야 합니다")
- `--quality` 가 1.0~100.0 범위 외 값을 silent 하게 인코더 단계 `clamp(1, 100)` 으로 처리하던 동작을 `parse_quality` 로 명시 거부 ("품질은 1.0~100.0 범위여야 합니다")
- clap v4 의 `value_parser!().range(..)` 는 정수만 지원하고 f32 는 안 됨 — 양쪽 다 사용자 정의 파서로 통일하여 한국어 에러 메시지를 직접 작성
- `src/main.rs` 에 `#[cfg(test)] mod tests` 추가 — 단위 테스트 6개 (`parse_quality_*` 3 + `parse_threads_*` 3): 정상 범위 통과 / 범위 외 거부 / 비숫자 거부 / 한국어 메시지 포함 검증
- 23 통합 + 6 단위 = 29 테스트 모두 통과
- `-t` doc 주석 / README 옵션 설명 / TESTING.md / CLAUDE.md / MEMORY.md 갱신
- 한계: `-q -10` 같은 음수 short flag 는 clap 단계에서 unknown option 으로 차단됨 — `--quality=-10` / `-q 0.5` 형태로는 우리 검증이 정상 차단하므로 별도 워크어라운드 보류