### PR TITLE
build: Docker 개발 환경 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/target
+/.git
+/.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ Conventional Commits + 한국어 본문.
 - 변경 내용 1
 - 변경 내용 2
 
-Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+Co-authored-by: <agent-name> <agent-email>
 ```
 
 **type**: `feat` · `fix` · `refactor` · `chore` · `docs` · `style` · `test` · `perf` · `ci` · `build` · `revert` · `init` · `remove` · `rename` · `hotfix`
@@ -125,7 +125,7 @@ Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 **규칙**
 - 제목은 type 뒤 한국어. 영어 고유명사/기술용어/심볼은 그대로
 - 본문은 `-` 리스트, 백틱으로 코드/심볼 인용 가능
-- 마지막 줄에 `Co-authored-by:` (소문자 `a`/`b`) 트레일러 — Claude Code 기본 템플릿(`Co-Authored-By` 대문자) 대신 이 형식 우선
+- 마지막 줄에 `Co-authored-by:` (소문자 `a`/`b`) 트레일러 — 함께 작업한 에이전트에 맞는 이름/이메일 사용
 - PR squash merge 시 제목 끝에 `(#N)` 자동 부착
 
 ## 향후 개선 후보
@@ -141,5 +141,5 @@ Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 - `README.md` — 사용자용 사용법, 옵션, 예제 출력
 - `PROJECT_STRUCTURE.md` — 모듈별 책임, 의존성 흐름, 향후 개선 제안
-- `TESTING.md` — 테스트 실행 방법, 테스트 목록 (12개), 매크로 사용법
+- `TESTING.md` — 테스트 실행 방법, 테스트 목록, 매크로 사용법
 - `MEMORY.md` — 작업 컨텍스트, 결정 기록, 진행 중/대기 항목 (세션 간 인계용)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG RUST_IMAGE=rust:1-trixie
+FROM ${RUST_IMAGE}
+
+LABEL org.opencontainers.image.title="image-converter 개발 환경"
+LABEL org.opencontainers.image.description="Rust 이미지 변환기용 격리 개발 컨테이너"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libdav1d-dev \
+        nasm \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+ENV CARGO_TARGET_DIR=/workspace/target
+ENV RUST_BACKTRACE=1
+
+CMD ["/bin/bash"]

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,6 +12,21 @@
 
 ## 최근 작업 로그
 
+### 2026-05-01 — Docker 개발 환경 추가
+
+- WSL 에서 작업하던 Rust 프로젝트를 macOS / 새 MacBook 으로 옮겨도 같은 개발 환경을 쓰기 위해 Docker 기반 격리 환경 추가
+- 신규 `Dockerfile` — `rust:1-trixie` 기반, AVIF 빌드/디코딩에 필요한 `nasm`, `libdav1d-dev`, `pkg-config` 설치. `CARGO_TARGET_DIR=/workspace/target`, `RUST_BACKTRACE=1` 설정
+- 신규 `docker-compose.yml` — 현재 repo 를 `/workspace` 로 bind mount, Cargo registry/git/target 은 Docker named volume 으로 분리해서 호스트에 Rust 빌드 산출물이 남지 않게 구성
+- 신규 `.dockerignore` — `target`, `.git`, `.DS_Store` 를 Docker build context 에서 제외
+- README/TESTING/PROJECT_STRUCTURE/CLAUDE 문서에 Docker 사용법 추가
+- 기본 이미지는 `rust:1-trixie`; `dav1d-sys` 가 `dav1d >= 1.3.0` 을 요구해서 Debian bookworm 의 `libdav1d-dev 1.0.0` 으로는 빌드 실패
+- 완전 고정이 필요하면 `RUST_IMAGE=rust:1.94-trixie docker compose build` 형태로 override 가능
+- 검증 완료:
+  - `docker compose config` 성공
+  - `docker compose build` 성공
+  - `docker compose run --rm dev cargo test` 성공 — lib 35개 + bin 6개 = 총 41개 테스트 통과
+  - 컨테이너 버전: `cargo 1.95.0`, `rustc 1.95.0`, `dav1d 1.5.1`
+
 ### 2026-04-30 — `refactor: 대화형 모드 검증 분리 + 단위 테스트 + threads 질문 추가` (PR 진행 중)
 
 - `src/interactive.rs` — `validate_with` 인라인 클로저와 디폴트 출력 경로 인라인 코드를 5개 순수 함수로 분리:

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -5,6 +5,9 @@
 ```
 image_converter/
 ├── .gitignore              # Git 무시 파일 설정
+├── .dockerignore           # Docker 빌드 컨텍스트 제외 파일
+├── Dockerfile              # Rust + nasm + dav1d 개발 컨테이너 이미지
+├── docker-compose.yml      # 개발/테스트용 컨테이너 실행 설정
 ├── Cargo.toml              # Rust 프로젝트 설정 및 의존성
 ├── README.md               # 프로젝트 사용 가이드
 ├── TESTING.md              # 테스트 실행 가이드
@@ -87,6 +90,12 @@ image_converter/
 - 단위 테스트와 통합 테스트 분리
 - 테스트 유틸리티 및 매크로
 - 깔끔한 테스트 출력
+
+### Docker 개발 환경
+
+- `Dockerfile`: 공식 Rust Debian 이미지를 기반으로 `nasm`, `libdav1d-dev`, `pkg-config` 를 설치
+- `docker-compose.yml`: 현재 작업 디렉토리를 `/workspace` 로 마운트하고 Cargo registry/git/target 을 Docker named volume 으로 분리
+- 기본 이미지는 `rust:1-trixie` (`dav1d >= 1.3.0` 필요), 필요 시 `RUST_IMAGE=rust:1.94-trixie docker compose build` 처럼 고정 가능
 
 ## 장점
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,44 @@
 
 ## 📦 설치
 
+### Docker 개발 환경 (추천)
+
+로컬 OS 에 Rust / `nasm` / `dav1d` 를 직접 설치하지 않고, 컨테이너 안에서 빌드와 테스트를 실행할 수 있습니다. WSL, macOS, 새 MacBook 으로 옮겨도 같은 Debian 기반 환경을 사용합니다.
+
+```bash
+# 개발 이미지 빌드
+docker compose build
+
+# 테스트 실행
+docker compose run --rm dev cargo test
+
+# 릴리즈 빌드
+docker compose run --rm dev cargo build --release
+
+# 컨테이너 안에서 CLI 실행
+docker compose run --rm dev cargo run --release -- -i input.png -o output.webp -f webp
+
+# 대화형 모드 실행
+docker compose run --rm dev cargo run --release -- -I
+
+# 컨테이너 안에서 셸 열기
+docker compose run --rm dev
+```
+
+`target` 과 Cargo registry/git 캐시는 Docker named volume 에 저장되어 호스트 프로젝트 디렉토리를 빌드 산출물로 어지럽히지 않습니다. 그래서 기본 흐름은 `cargo run` 도 컨테이너 안에서 실행하는 방식입니다. 완전히 새로 받고 싶으면 다음처럼 볼륨까지 지웁니다.
+
+```bash
+docker compose down -v
+```
+
+기본 Rust 이미지는 `rust:1-trixie` 입니다. `dav1d-sys` 가 `dav1d >= 1.3.0` 을 요구하므로 Debian bookworm 대신 trixie 를 사용합니다. 특정 버전으로 고정하고 싶으면 `.env` 파일이나 명령 앞 환경변수로 바꿀 수 있습니다.
+
+```bash
+RUST_IMAGE=rust:1.94-trixie docker compose build
+```
+
+### 로컬 설치
+
 1. Rust가 설치되어 있어야 합니다. [Rust 설치 가이드](https://www.rust-lang.org/tools/install)를 참고하세요.
 2. **시스템 라이브러리 설치** — AVIF 인코딩(`rav1e`)에는 `nasm`, AVIF 디코딩(`dav1d`)에는 `libdav1d` 가 필요합니다.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -20,6 +20,28 @@ src/
 
 ## 테스트 실행 방법
 
+### Docker 로 실행 (추천)
+```bash
+docker compose build
+docker compose run --rm dev cargo test
+```
+
+테스트 출력까지 보고 싶으면 다음처럼 실행합니다.
+
+```bash
+docker compose run --rm dev cargo test -- --nocapture
+```
+
+릴리즈 모드 테스트도 컨테이너 안에서 실행할 수 있습니다.
+
+```bash
+docker compose run --rm dev cargo test --release
+```
+
+컨테이너의 `target` 과 Cargo 캐시는 Docker named volume 에 저장됩니다. 캐시까지 초기화하려면 `docker compose down -v` 를 실행합니다.
+
+### 로컬 Rust 로 실행
+
 ### 기본 테스트 실행
 ```bash
 cargo test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        RUST_IMAGE: ${RUST_IMAGE:-rust:1-trixie}
+    image: image-converter-dev
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+      - cargo-registry:/usr/local/cargo/registry
+      - cargo-git:/usr/local/cargo/git
+      - target:/workspace/target
+    environment:
+      CARGO_TARGET_DIR: /workspace/target
+      RUST_BACKTRACE: "1"
+    stdin_open: true
+    tty: true
+
+volumes:
+  cargo-registry:
+  cargo-git:
+  target:


### PR DESCRIPTION
- Rust / nasm / dav1d 시스템 의존성을 포함한 Dockerfile 추가
- docker compose 로 개발 셸, 빌드, 테스트를 실행할 수 있게 구성
- Cargo registry/git/target 을 Docker named volume 으로 분리해 호스트 환경 오염 최소화
- dav1d-sys 의 dav1d >= 1.3.0 요구사항에 맞춰 rust:1-trixie 기반 이미지 사용
- README / TESTING / PROJECT_STRUCTURE / CLAUDE / AGENTS / MEMORY 문서에 Docker 사용법과 검증 결과 반영
- AGENTS.md 의 커밋 트레일러 예시를 에이전트별 이름/이메일을 쓰는 형태로 정리
- docker compose build 및 docker compose run --rm dev cargo test 로 41개 테스트 통과 확인