### PR TITLE
chore: 로컬 품질 검사와 버전 표시 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,7 @@ Docker 사용을 기본으로 합니다. 로컬 OS 에 Rust, `nasm`, `dav1d` 를
 
 ```bash
 docker compose build
-docker compose run --rm dev cargo fmt --check
-docker compose run --rm dev cargo test
+./scripts/check.sh
 docker compose run --rm dev cargo build --release
 docker compose run --rm dev cargo run --release -- -I
 ```
@@ -50,7 +49,7 @@ docker compose run --rm dev cargo run --release -- -I
 
 - 변경 전 관련 모듈과 테스트를 먼저 확인
 - 기능 변경은 가능한 한 작은 단위로 분리
-- Docker 환경에서 `cargo fmt --check` 와 `cargo test` 로 검증
+- Docker 환경에서 `./scripts/check.sh` 로 포맷팅, Clippy, 테스트를 함께 검증
 - 문서 구조나 개발 흐름을 바꾸면 `README.md`, `docs/architecture.md`, `docs/testing.md`, `docs/memory.md` 중 필요한 문서를 함께 갱신
 - `docs/memory.md` 에는 시간에 따라 변하는 작업 로그와 결정 기록만 추가
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "image_converter"
-version = "0.1.0"
+version = "2.4.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image_converter"
-version = "0.1.0"
+version = "2.4.0"
 edition = "2021"
 
 [lib]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rustup component add rustfmt
+RUN rustup component add rustfmt clippy
 
 WORKDIR /workspace
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,17 @@
 # 개발 이미지 빌드
 docker compose build
 
+# 전체 품질 검사 (포맷팅 + Clippy + 테스트)
+./scripts/check.sh
+
 # 테스트 실행
 docker compose run --rm dev cargo test
 
 # 포맷팅
-docker compose run --rm dev cargo fmt
+docker compose run --rm dev cargo fmt --check
+
+# 린트
+docker compose run --rm dev cargo clippy --all-targets --all-features -- -D warnings
 
 # 릴리즈 빌드
 docker compose run --rm dev cargo build --release
@@ -61,6 +67,8 @@ docker compose run --rm dev cargo run --release -- -I
 # 컨테이너 안에서 셸 열기
 docker compose run --rm dev
 ```
+
+호스트에 Rust 와 시스템 의존성을 직접 설치한 경우에는 `./scripts/check.sh --local` 로 같은 검사를 로컬 Cargo 로 실행할 수 있습니다.
 
 `target` 과 Cargo registry/git 캐시는 Docker named volume 에 저장되어 호스트 프로젝트 디렉토리를 빌드 산출물로 어지럽히지 않습니다. 그래서 기본 흐름은 `cargo run` 도 컨테이너 안에서 실행하는 방식입니다. 완전히 새로 받고 싶으면 다음처럼 볼륨까지 지웁니다.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,8 @@ image_converter/
 ├── docker-compose.yml      # 개발/테스트용 컨테이너 실행 설정
 ├── Cargo.toml              # Rust 프로젝트 설정 및 의존성
 ├── README.md               # 프로젝트 사용 가이드
+├── scripts/
+│   └── check.sh            # 로컬 품질 검사 (fmt + clippy + test)
 ├── docs/
 │   ├── README.md           # 개발 문서 인덱스
 │   ├── architecture.md     # 이 문서
@@ -90,6 +92,7 @@ image_converter/
 ### `utils.rs` (공통 유틸리티)
 
 - 파일 크기 포맷팅
+- 출력 요약의 품질/무손실 라벨 포맷팅
 - 기타 헬퍼 함수
 
 ### `lib.rs` (라이브러리 인터페이스)
@@ -105,8 +108,9 @@ image_converter/
 
 ### Docker 개발 환경
 
-- `Dockerfile`: 공식 Rust Debian 이미지를 기반으로 `nasm`, `libdav1d-dev`, `pkg-config`, `rustfmt` 를 설치
+- `Dockerfile`: 공식 Rust Debian 이미지를 기반으로 `nasm`, `libdav1d-dev`, `pkg-config`, `rustfmt`, `clippy` 를 설치
 - `docker-compose.yml`: 현재 작업 디렉토리를 `/workspace` 로 마운트하고 Cargo registry/git/target 을 Docker named volume 으로 분리
+- `scripts/check.sh`: Docker 컨테이너에서 `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` 를 한 번에 실행. `--local` 옵션을 주면 호스트 Cargo 로 실행
 - 기본 이미지는 `rust:1-trixie` (`dav1d >= 1.3.0` 필요), 필요 시 `RUST_IMAGE=rust:1.94-trixie docker compose build` 처럼 고정 가능
 
 ## 장점

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,6 +12,31 @@
 
 ## 최근 작업 로그
 
+### 2026-05-01 — 버전 단일화 + PNG 요약 라벨 개선
+
+- `Cargo.toml` 패키지 버전을 `2.4.0` 으로 올리고, `src/main.rs` 의 clap 버전은 하드코딩 대신 Cargo 패키지 버전을 사용하도록 변경
+  - `docker compose run --rm dev cargo run -- --version` 출력: `image_converter 2.4.0`
+- 출력 요약의 품질 표시를 `src/utils.rs` 의 `format_quality_label(format, quality)` 로 공통화
+  - WebP/JPEG/AVIF: 기존처럼 `품질: N%`
+  - PNG: 품질 값 대신 `무손실`
+- 단일 변환(`converter.rs`) 과 일괄 변환(`batch.rs`) 요약이 같은 라벨 규칙을 사용하도록 변경
+- `format_quality_label` 단위 테스트 2개 추가 — 손실 포맷 품질 라벨 + PNG 무손실 라벨
+- README / docs/testing.md / docs/architecture.md 갱신
+- `./scripts/check.sh` 성공 — fmt 통과, Clippy 경고 없음, lib 37개 + bin 8개 = 총 45개 테스트 통과
+
+### 2026-05-01 — 로컬 품질 검사 스크립트 추가
+
+- GitHub Actions 같은 원격 CI 는 아직 도입하지 않고, 로컬에서 한 번에 검사하는 스크립트 방식으로 결정
+- 신규 `scripts/check.sh` 추가
+  - 기본: Docker 개발 컨테이너에서 `cargo fmt --check` → `cargo clippy --all-targets --all-features -- -D warnings` → `cargo test` 순서로 실행
+  - `--local`: 호스트에 설치된 Cargo 로 같은 검사 실행
+  - `--release`: 테스트만 release 모드로 실행
+- `Dockerfile` 에 `clippy` 컴포넌트 설치 추가 (`rustup component add rustfmt clippy`)
+- README / docs/testing.md / docs/architecture.md / AGENTS.md 에 로컬 검사 스크립트 사용법 반영
+- 검증 완료:
+  - `docker compose build` 성공
+  - `./scripts/check.sh` 성공 — fmt 통과, Clippy 경고 없음, lib 35개 + bin 8개 = 총 43개 테스트 통과
+
 ### 2026-05-01 — 문서 구조 정리
 
 - 루트 문서가 많아진 문제를 줄이기 위해 상세 개발 문서를 `docs/` 아래로 이동

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,6 +23,14 @@ src/
 ### Docker 로 실행 (추천)
 ```bash
 docker compose build
+./scripts/check.sh
+```
+
+`scripts/check.sh` 는 Docker 개발 컨테이너에서 다음 검사를 순서대로 실행합니다.
+
+```bash
+docker compose run --rm dev cargo fmt --check
+docker compose run --rm dev cargo clippy --all-targets --all-features -- -D warnings
 docker compose run --rm dev cargo test
 ```
 
@@ -41,6 +49,12 @@ docker compose run --rm dev cargo test --release
 컨테이너의 `target` 과 Cargo 캐시는 Docker named volume 에 저장됩니다. 캐시까지 초기화하려면 `docker compose down -v` 를 실행합니다.
 
 ### 로컬 Rust 로 실행
+
+호스트에 Rust 와 시스템 의존성(`nasm`, `dav1d`, `pkg-config`) 을 직접 설치한 경우에는 같은 검사를 로컬 Cargo 로 실행할 수 있습니다.
+
+```bash
+./scripts/check.sh --local
+```
 
 #### 기본 테스트 실행
 ```bash
@@ -99,130 +113,134 @@ cargo test --release
    - 단위가 바뀌는 경계에서 올바르게 동작하는지 확인
    - 1023B (1KB 직전), 1MB 직전, 1GB 직전 테스트
 
+3. **`test_format_quality_label_*`** (2개)
+   - 손실 포맷(WebP/JPEG/AVIF)은 품질 값을 표시하는지 확인
+   - PNG 는 품질 값 대신 "무손실" 로 표시하는지 확인
+
 ### 🔄 통합 테스트 (Integration Tests)
 
-3. **`test_webp_conversion`**
+4. **`test_webp_conversion`**
    - PNG → WebP 변환 기능 전체 테스트
    - 변환이 정상적으로 작동하고, 파일 크기가 감소하는지 확인
 
-4. **`test_avif_conversion`**
+5. **`test_avif_conversion`**
    - PNG → AVIF 변환 기능 전체 테스트
    - 변환이 정상적으로 작동하고, 파일 크기가 감소하는지 확인
 
-5. **`test_quality_parameter_bounds`**
+6. **`test_quality_parameter_bounds`**
    - 품질 파라미터 경계값 테스트
    - 최소값(1)과 최대값(100)에서 정상 작동하는지 확인
 
 ### 📂 디렉토리 일괄 변환 테스트
 
-6. **`test_batch_directory_conversion`**
+7. **`test_batch_directory_conversion`**
    - 디렉토리 안의 PNG 3개를 일괄 변환
    - 모든 파일이 성공적으로 변환되고 출력 디렉토리에 생성되는지 확인
 
-7. **`test_batch_skips_non_image_files`**
+8. **`test_batch_skips_non_image_files`**
    - `.txt`, `.md` 같은 비이미지 파일은 자동으로 스킵되는지 확인
 
-8. **`test_batch_recursive_conversion`**
+9. **`test_batch_recursive_conversion`**
    - 재귀 옵션 사용 시 하위 디렉토리도 처리되고, 출력에 구조가 미러링되는지 확인
 
-9. **`test_batch_non_recursive_skips_subdirs`**
+10. **`test_batch_non_recursive_skips_subdirs`**
    - 재귀 옵션 없이 실행 시 하위 디렉토리는 무시되는지 확인
 
-10. **`test_batch_empty_directory`**
+11. **`test_batch_empty_directory`**
     - 이미지가 없는 디렉토리에서도 에러 없이 0개 처리로 끝나는지 확인
 
 ### ❌ 에러 처리 테스트
 
-11. **`test_invalid_format`**
+12. **`test_invalid_format`**
     - 지원하지 않는 형식으로 변환 시도 시 에러 처리 테스트
     - 올바른 에러 메시지가 반환되는지 확인
 
-12. **`test_nonexistent_input_file`**
+13. **`test_nonexistent_input_file`**
     - 존재하지 않는 입력 파일 처리 테스트
     - 파일이 없을 때 적절한 에러가 발생하는지 확인
 
 ### 🔁 다중 포맷 입출력 테스트
 
-13. **`test_png_output_from_webp_input`**
+14. **`test_png_output_from_webp_input`**
     - WebP → PNG 역변환이 동작하는지 확인 (`encode_to` 의 PNG 분기 + WebP 디코딩)
     - 출력 파일이 PNG 매직 바이트(`89 50 4E 47`) 로 시작하는지 검증
 
-14. **`test_jpeg_output_from_png_input`**
+15. **`test_jpeg_output_from_png_input`**
     - PNG → JPEG 변환이 동작하는지 확인
     - 출력 파일이 JPEG 매직 바이트(`FF D8 FF`) 로 시작하는지 검증
 
-15. **`test_jpg_alias_for_jpeg`**
+16. **`test_jpg_alias_for_jpeg`**
     - 포맷 인자 `"jpg"` 와 `"jpeg"` 가 같은 JPEG 인코딩 분기로 매핑되는지 확인
 
-16. **`test_tiff_input_to_webp`**
+17. **`test_tiff_input_to_webp`**
     - TIFF 입력이 디코딩되어 WebP 로 변환되는지 확인 (`is_supported_image` 화이트리스트 + `image::open` TIFF 디코더)
 
-17. **`test_bmp_input_to_jpeg`**
+18. **`test_bmp_input_to_jpeg`**
     - BMP 입력이 디코딩되어 JPEG 로 변환되는지 확인
 
-18. **`test_batch_mixed_input_formats`**
+19. **`test_batch_mixed_input_formats`**
     - PNG + WebP + AVIF + TIFF + BMP 5종이 한 디렉토리에 섞여 있을 때 모두 PNG 로 일괄 변환되는지 확인 (배치 모드의 입력 화이트리스트 + 다중 디코더 결합 검증)
 
-19. **`test_avif_input_to_png`**
+20. **`test_avif_input_to_png`**
     - AVIF → PNG 라운드트립이 동작하는지 확인 (`avif-decoder` feature + `dav1d` 디코딩, 8-bit AVIF 인코딩)
     - 출력 파일이 PNG 매직 바이트로 시작하는지 검증
 
-20. **`test_batch_with_explicit_threads`**
+21. **`test_batch_with_explicit_threads`**
     - `convert_directory()` 의 `threads: Option<usize>` 인자 검증
     - `None` (기본) 과 `Some(1)` (단일 스레드) 두 모드에서 같은 입력에 대해 같은 성공 개수가 나오는지 확인 (스레드 수에 결과가 영향받지 않아야 함)
 
-21. **`test_jpeg_input_to_webp`**
+22. **`test_jpeg_input_to_webp`**
     - JPEG 입력을 WebP 로 변환하는 명시적 단일 케이스
     - 출력 파일이 RIFF/WEBP 시그니처로 시작하는지 검증
 
-22. **`test_jpeg_input_to_png`**
+23. **`test_jpeg_input_to_png`**
     - JPEG 입력을 PNG 로 변환 (JPEG 디코더 + PNG 인코더 결합)
     - 출력이 PNG 매직 바이트(`89 50 4E 47`) 로 시작하는지 검증
 
-23. **`test_jpg_extension_input`**
+24. **`test_jpg_extension_input`**
     - 입력 측 `.jpg` 확장자도 JPEG 디코더로 정상 인식되는지 확인 (`.jpg`/`.jpeg` 양쪽 별칭 회귀 방지)
 
 ### 🛠️ CLI 인자 파서 단위 테스트 (`src/main.rs`)
 
-24. **`parse_quality_accepts_valid_range`**
+25. **`parse_quality_accepts_valid_range`**
     - `--quality` 가 1.0 / 50.5 / 100.0 같은 정상 범위 값을 통과시키는지 확인
 
-25. **`parse_quality_rejects_out_of_range`**
+26. **`parse_quality_rejects_out_of_range`**
     - 0, 0.99, 100.01, -10, 200 같은 범위 외 값이 거부되는지 확인
 
-26. **`parse_quality_rejects_non_numeric`**
+27. **`parse_quality_rejects_non_numeric`**
     - `"abc"` 같은 비숫자 입력이 한국어 에러 메시지("유효한 숫자가 아닙니다") 와 함께 거부되는지 확인
 
-27. **`parse_threads_accepts_positive`**
+28. **`parse_threads_accepts_positive`**
     - `--threads` 가 1, 16 같은 양의 정수를 통과시키는지 확인
 
-28. **`parse_threads_rejects_zero`**
+29. **`parse_threads_rejects_zero`**
     - 0 이 거부되고 한국어 에러 메시지("1 이상") 가 포함되는지 확인 (rayon 풀 빌드 단계 panic 방지)
 
-29. **`parse_threads_rejects_non_numeric`**
+30. **`parse_threads_rejects_non_numeric`**
     - 비숫자(`"abc"`) 와 음수(`"-1"`) 입력 거부 확인
 
-30. **`parse_format_accepts_valid_values_case_insensitive`**
+31. **`parse_format_accepts_valid_values_case_insensitive`**
     - `--format WEBP` 처럼 대문자로 입력해도 `OutputFormat::Webp` 로 파싱되는지 확인
 
-31. **`parse_format_rejects_invalid_value`**
+32. **`parse_format_rejects_invalid_value`**
     - `--format xyz` 같은 미지원 출력 포맷을 clap 단계에서 거부하는지 확인
 
 ### 🎯 대화형 모드 검증 단위 테스트 (`src/interactive.rs`)
 
-32. **`validate_input_path_*`** (4개)
+33. **`validate_input_path_*`** (4개)
     - 존재하지 않는 경로 거부, 단일 모드에 디렉토리 입력 거부, 배치 모드에 파일 입력 거부, 정상 케이스(파일/디렉토리) 통과
 
-33. **`validate_quality_input_*`** (2개)
+34. **`validate_quality_input_*`** (2개)
     - 1.0/50.5/100.0 정상 범위 통과, 0 / 0.99 / 100.01 / -10 / `"abc"` 거부
 
-34. **`validate_threads_input_*`** (2개)
+35. **`validate_threads_input_*`** (2개)
     - 1, 16 통과, 0 / -1 / `"abc"` / 빈 입력 거부
 
-35. **`default_output_path_for_file_*`** (2개)
+36. **`default_output_path_for_file_*`** (2개)
     - `{stem}_converted.{format}` 패턴 (예: `photo.png` + webp → `photo_converted.webp`), 확장자 없는 입력 (`no_ext` + png → `no_ext_converted.png`) 처리
 
-36. **`default_output_path_for_dir_*`** (2개)
+37. **`default_output_path_for_dir_*`** (2개)
     - `{dirname}_converted_{format}` 패턴 (예: `photos` + webp → `photos_converted_webp`), trailing slash (`/tmp/photos/`) 정상 처리
 
 ## 테스트 매크로
@@ -283,8 +301,9 @@ fn test_new_feature() {
 
 ## 테스트 커버리지
 
-현재 테스트는 다음 영역을 커버합니다 (총 43개):
+현재 테스트는 다음 영역을 커버합니다 (총 45개):
 - ✅ 파일 크기 포맷팅
+- ✅ 출력 요약 라벨 (PNG 무손실 / 손실 포맷 품질 표시)
 - ✅ WebP / AVIF 단일 변환
 - ✅ 품질 파라미터 검증
 - ✅ 디렉토리 일괄 변환 (재귀 / 비재귀)

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+USE_LOCAL=0
+RELEASE_TEST=0
+
+usage() {
+    cat <<'USAGE'
+사용법: scripts/check.sh [--local] [--release]
+
+기본값은 Docker 개발 컨테이너에서 실행합니다.
+  scripts/check.sh           # fmt + clippy + test
+  scripts/check.sh --local   # 호스트에 설치된 cargo 사용
+  scripts/check.sh --release # release 모드 테스트 실행
+
+필요 도구:
+  기본: docker compose
+  --local: cargo, rustfmt, clippy, nasm, dav1d/pkg-config
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --local)
+            USE_LOCAL=1
+            ;;
+        --release)
+            RELEASE_TEST=1
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "알 수 없는 옵션: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+run() {
+    echo
+    printf '==> '
+    printf '%q ' "$@"
+    echo
+    "$@"
+}
+
+if [[ "$USE_LOCAL" -eq 1 ]]; then
+    CARGO_CMD=(cargo)
+else
+    CARGO_CMD=(docker compose run --rm dev cargo)
+fi
+
+run "${CARGO_CMD[@]}" fmt --check
+run "${CARGO_CMD[@]}" clippy --all-targets --all-features -- -D warnings
+
+if [[ "$RELEASE_TEST" -eq 1 ]]; then
+    run "${CARGO_CMD[@]}" test --release
+else
+    run "${CARGO_CMD[@]}" test
+fi

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -7,7 +7,7 @@ use walkdir::WalkDir;
 use crate::converter::{convert_image_silent, ConvertStats};
 use crate::error::{ConverterError, Result};
 use crate::format::OutputFormat;
-use crate::utils::format_file_size;
+use crate::utils::{format_file_size, format_quality_label};
 
 /// 디렉토리 변환 결과 합계
 pub struct BatchSummary {
@@ -176,7 +176,7 @@ pub fn convert_directory(
     }
 
     pb.finish_with_message("✅ 일괄 변환 완료!");
-    print_batch_summary(&summary, quality);
+    print_batch_summary(&summary, format, quality);
     Ok(summary)
 }
 
@@ -245,7 +245,7 @@ fn process_one(
     result
 }
 
-fn print_batch_summary(summary: &BatchSummary, quality: f32) {
+fn print_batch_summary(summary: &BatchSummary, format: OutputFormat, quality: f32) {
     println!("\n{} 일괄 변환 결과:", "📊".bright_blue());
     println!(
         "  {} 처리 대상: {}개",
@@ -274,10 +274,10 @@ fn print_batch_summary(summary: &BatchSummary, quality: f32) {
             format_file_size(summary.total_input_size).bright_yellow()
         );
         println!(
-            "  {} 변환 합계: {} (품질: {}%)",
+            "  {} 변환 합계: {} ({})",
             "💾".bright_green(),
             format_file_size(summary.total_output_size).bright_green(),
-            quality as u32
+            format_quality_label(format, quality)
         );
         println!(
             "  {} 평균 용량 감소: {:.1}% {}",

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -136,14 +136,22 @@ pub fn convert_image(
             width,
             height,
         },
+        format,
         quality,
     );
     Ok(())
 }
 
-fn print_single_summary(input_path: &str, output_path: &str, stats: &ConvertStats, quality: f32) {
+fn print_single_summary(
+    input_path: &str,
+    output_path: &str,
+    stats: &ConvertStats,
+    format: OutputFormat,
+    quality: f32,
+) {
     let reduction =
         ((stats.input_size as f64 - stats.output_size as f64) / stats.input_size as f64) * 100.0;
+    let quality_label = crate::utils::format_quality_label(format, quality);
 
     println!("\n{} 변환 결과:", "📊".bright_blue());
     println!(
@@ -154,10 +162,10 @@ fn print_single_summary(input_path: &str, output_path: &str, stats: &ConvertStat
         stats.height
     );
     println!(
-        "  {} 변환: {} (품질: {}%)",
+        "  {} 변환: {} ({})",
         "💾".bright_green(),
         crate::utils::format_file_size(stats.output_size).bright_green(),
-        quality as u32
+        quality_label
     );
 
     let emoji = pick_reduction_emoji(reduction);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,4 @@ pub use batch::{convert_directory, BatchSummary};
 pub use converter::{convert_image, convert_image_silent, ConvertStats};
 pub use error::{ConverterError, Result};
 pub use format::OutputFormat;
-pub use utils::format_file_size;
+pub use utils::{format_file_size, format_quality_label};

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn parse_threads(s: &str) -> Result<usize, String> {
 
 /// PNG/JPG/JPEG/WebP/AVIF/TIFF/BMP/ICO 이미지를 PNG/JPG/WebP/AVIF 로 변환합니다 (단일 파일 + 디렉토리 일괄)
 #[derive(Parser, Debug)]
-#[command(name = "image_converter", version = "2.4", about, long_about = None)]
+#[command(name = "image_converter", version, about, long_about = None)]
 struct Cli {
     /// 대화형 모드로 실행
     #[arg(short = 'I', long)]

--- a/src/tests/unit_tests.rs
+++ b/src/tests/unit_tests.rs
@@ -1,4 +1,4 @@
-use crate::format_file_size;
+use crate::{format_file_size, format_quality_label, OutputFormat};
 use crate::{test_description, test_step, test_success};
 
 #[test]
@@ -47,4 +47,29 @@ fn test_format_file_size_edge_cases() {
     // 1GB 직전
     assert_eq!(format_file_size(1024 * 1024 * 1024 - 1), "1024.00 MB");
     test_success!("1GB 직전 처리 완료");
+}
+
+#[test]
+fn test_format_quality_label_for_lossy_formats() {
+    test_description!("손실 압축 포맷의 품질 라벨 테스트");
+    test_step!("WebP/JPEG/AVIF 는 품질 값을 표시하는지 확인");
+
+    assert_eq!(format_quality_label(OutputFormat::Webp, 90.0), "품질: 90%");
+    assert_eq!(format_quality_label(OutputFormat::Jpeg, 85.5), "품질: 85%");
+    assert_eq!(
+        format_quality_label(OutputFormat::Avif, 100.0),
+        "품질: 100%"
+    );
+
+    test_success!("손실 포맷 품질 라벨 확인");
+}
+
+#[test]
+fn test_format_quality_label_for_png() {
+    test_description!("PNG 무손실 라벨 테스트");
+    test_step!("PNG 는 품질 값 대신 무손실로 표시하는지 확인");
+
+    assert_eq!(format_quality_label(OutputFormat::Png, 90.0), "무손실");
+
+    test_success!("PNG 무손실 라벨 확인");
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use crate::format::OutputFormat;
+
 /// 파일 크기를 사람이 읽기 쉬운 형식으로 변환하는 함수
 pub fn format_file_size(size: u64) -> String {
     const UNITS: &[&str] = &["B", "KB", "MB", "GB"];
@@ -10,4 +12,13 @@ pub fn format_file_size(size: u64) -> String {
     }
 
     format!("{:.2} {}", size, UNITS[unit_index])
+}
+
+/// 출력 요약에 표시할 품질/무손실 라벨
+pub fn format_quality_label(format: OutputFormat, quality: f32) -> String {
+    if format.is_png() {
+        "무손실".to_string()
+    } else {
+        format!("품질: {}%", quality as u32)
+    }
 }


### PR DESCRIPTION
- scripts/check.sh 로 fmt, clippy, test 를 한 번에 실행하도록 추가
- Docker 개발 이미지에 clippy 컴포넌트를 설치
- Cargo 패키지 버전을 2.4.0 으로 맞추고 CLI 버전 표시를 패키지 버전에 연결
- PNG 출력 요약은 무손실로, 손실 포맷은 품질 라벨로 표시하도록 공통화
- 관련 문서와 작업 메모리를 갱신