### PR TITLE
test: 대화형 모드 통합 테스트 추가

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +297,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +363,12 @@ dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "comma"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "console"
@@ -644,6 +665,7 @@ dependencies = [
  "indicatif",
  "ravif",
  "rayon",
+ "rexpect",
  "tempfile",
  "thiserror 1.0.69",
  "walkdir",
@@ -748,9 +770,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -853,6 +875,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -1141,6 +1175,48 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rexpect"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e459b12e442eb95f78b7e69bb2c3a64fc96f24d90dbc47fb028d94ffb26ce1e8"
+dependencies = [
+ "comma",
+ "nix",
+ "regex",
+ "tempfile",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ rayon = "1.10"
 [dev-dependencies]
 tempfile = "3.0"
 colored = "2.1"
+
+[target.'cfg(unix)'.dev-dependencies]
+rexpect = "0.7.0"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,8 @@ image_converter/
 │   ├── testing.md          # 테스트 실행 가이드
 │   ├── release-notes.md    # 버전별 주요 변경 사항
 │   └── memory.md           # 작업 로그와 결정 기록
+├── tests/
+│   └── interactive_cli.rs  # 대화형 CLI PTY 통합 테스트
 └── src/
     ├── main.rs             # 진입점 - CLI 인자 처리, 단일/일괄 분기
     ├── lib.rs              # 라이브러리 루트 - 공개 API re-export
@@ -122,6 +124,7 @@ image_converter/
 - 단위 테스트와 통합 테스트 분리
 - 테스트 유틸리티 및 매크로
 - 깔끔한 테스트 출력
+- 루트 `tests/interactive_cli.rs` 는 `rexpect` 로 실제 PTY 에서 바이너리를 실행해 `dialoguer` 기반 대화형 흐름을 검증
 
 ### Docker 개발 환경
 
@@ -162,7 +165,7 @@ main.rs
 
 1. **`image` 0.25 업그레이드**: 10-bit AVIF 디코딩 지원. breaking change 가 있어 별도 작업
 2. **HEIC 입력**: iPhone 사진 변환용. `libheif` 시스템 의존성 + 외부 크레이트
-3. **대화형 모드 통합 테스트**: 현재는 검증/경로 빌더 단위 테스트만. `dialoguer` 의 `Select` 가 raw TTY 모드라 `rexpect` 등 PTY 도구 필요
+3. **대화형 모드 추가 PTY 시나리오**: 현재는 단일 파일 기본 흐름만 통합 테스트. 배치 모드, JPEG 배경색 직접 입력, 리사이즈 적용 흐름은 필요 시 추가
 4. **설정 모듈**: 품질 프리셋, 기본값 등을 관리하는 `config.rs`
 5. **다국어 지원**: 메시지를 별도 파일로 분리
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,6 +12,16 @@
 
 ## 최근 작업 로그
 
+### 2026-05-01 — 대화형 CLI PTY 통합 테스트 추가
+
+- `rexpect = "0.7.0"` 을 Unix 전용 dev-dependency 로 추가
+- 루트 `tests/interactive_cli.rs` 추가
+  - `CARGO_BIN_EXE_image_converter` 로 실제 바이너리를 인자 없이 실행
+  - `dialoguer` 대화형 프롬프트를 PTY 에서 조작해 단일 파일 기본 흐름을 검증
+  - PNG 입력을 기본 선택지(WebP, 품질 90, 리사이즈 없음, 기본 출력 경로)로 변환하고 WebP 시그니처 확인
+- `rexpect` 가 PTY 출력을 byte 단위 문자로 읽어서 한국어 프롬프트가 그대로 매칭되지 않는 문제는 테스트 헬퍼 `pty_text()` 로 기대 문자열을 같은 방식으로 변환해 해결
+- docs/architecture.md / docs/testing.md 갱신
+
 ### 2026-05-01 — 2.5.0 릴리즈 준비
 
 - `Cargo.toml` 패키지 버전을 `2.5.0` 으로 올림
@@ -358,7 +368,8 @@
 - **bin/lib 중복 컴파일 제거** — `main.rs` 가 `mod converter;` 등으로 모듈을 직접 포함하면 lib 과 bin 양쪽에서 같은 코드가 컴파일되고 `convert_image_silent` 가 bin 측에서 dead_code 경고. `main.rs` 를 `image_converter::*` 로 import 하도록 변경하여 해결.
 - **CLI 인자 검증은 사용자 정의 파서로 통일** — clap v4 의 `clap::value_parser!().range(..)` 는 정수 (`u16`/`usize` 등) 만 직접 지원하고 `f32`/`f64` 는 안 됨. quality (float) 와 threads (usize) 두 인자가 있어서 한쪽만 빌트인 range 를 쓰면 일관성이 깨지므로, 양쪽 다 `fn parse_quality(&str) -> Result<f32, String>` / `fn parse_threads(&str) -> Result<usize, String>` 사용자 정의 파서로 통일. 부수 효과로 한국어 에러 메시지 (`"품질은 1.0~100.0 범위여야 합니다"`) 를 직접 작성 가능 — clap 의 영어 wrapper (`"invalid value '0' for ..."`) 안에 우리 사유가 그대로 노출됨.
 - **음수 인자 (`-q -10`) 는 clap 한계로 별도 워크어라운드 안 함** — clap 은 `-` 시작 토큰을 short option 으로 해석해서 `-1` 이 unknown flag 로 거부됨. `allow_negative_numbers` attribute 를 켜면 우회 가능하지만 사용자가 음수 quality 를 의도적으로 넣는 경우는 거의 없고, `--quality=-10` / `-q 0.5` 형태로는 우리 검증이 정상 차단하므로 단순함을 위해 보류.
-- **대화형 모드 검증은 dialoguer 모킹 대신 순수 함수 분리로 단위 테스트** — `dialoguer::Select` 는 raw TTY 모드라 stdin pipe 시뮬레이션이 안 됨. PTY 도구 (`rexpect` 등) 도입은 환경 의존성이 커서 flaky 위험. 대신 `validate_with` 클로저와 디폴트 경로 빌더처럼 **검증 가치가 큰 순수 로직만 함수로 분리**하면 dialoguer 한 줄도 안 건드리고 단위 테스트 가능. 흐름 자체의 통합 테스트는 비용 대비 가치가 낮아 보류.
+- **대화형 모드 검증은 먼저 순수 함수 단위 테스트로 분리** — `dialoguer::Select` 는 raw TTY 모드라 stdin pipe 시뮬레이션이 안 됨. PTY 도구 (`rexpect` 등) 도입은 환경 의존성이 커서 처음에는 `validate_with` 클로저와 디폴트 경로 빌더처럼 **검증 가치가 큰 순수 로직만 함수로 분리**했다. 이후 실제 바이너리 smoke test 는 별도 PTY 통합 테스트로 보강.
+- **대화형 통합 테스트는 PTY smoke test 로 최소화** — raw TTY 가 필요한 `dialoguer` 흐름은 `rexpect` 로 실제 바이너리를 실행해 검증한다. 다만 PTY 테스트는 일반 단위 테스트보다 느리고 환경 의존성이 있으므로, 우선 인자 없는 실행의 단일 파일 기본 변환 흐름 하나만 smoke test 로 둔다.
 - **대화형 모드 스레드 수 질문은 한 단계 (`allow_empty=true`) 패턴** — 이전 결정 ("대화형 모드는 스레드 수 질문 안 함") 을 부분 뒤집음. `Confirm` (예/아니오) + `Input` (값) 두 단계로 나누면 친절하지만 늘어짐. 한 단계 (`Input::allow_empty(true)`) 로 통합: 빈 입력 = `None` (모든 코어), 숫자 = `Some(n)`. 사용자 친화 + 단계 수 최소.
 - **기존 출력 파일은 덮어쓰지 않음** — 단일 변환은 `OutputExists` 에러로 중단, 일괄 변환은 해당 파일만 `skipped` 로 집계. 출력 쓰기는 `create_new(true)` 로 처리해 변환 도중 같은 출력 경로가 생겨도 덮어쓰지 않음.
 - **인자 없는 실행은 대화형 모드** — 이 프로젝트의 기본 UX 는 사용자가 변환 의도를 단계적으로 선택하는 흐름. CLI 플래그는 자동화/반복 작업용 보조 수단으로 유지하고, 포맷 추론 같은 추가 규칙은 넣지 않음.
@@ -385,10 +396,11 @@
 - [x] **대화형 리사이즈 옵션** — 완료. 최대 가로 크기 기반 비율 유지 축소를 단일/일괄 변환에 적용. 원본보다 작을 때만 축소하고 확대하지 않음. 66 테스트 통과.
 - [x] **JPEG 배경색 옵션** — 완료. 대화형 JPEG 출력에서 투명 영역 배경색을 선택하고, 인코딩 전 알파 합성을 적용. 72 테스트 통과.
 - [x] **2.5.0 릴리즈 준비** — 완료. 버전 bump + 릴리즈 노트 추가.
+- [x] **대화형 모드 통합 테스트** — 완료. `rexpect` PTY 테스트로 인자 없는 단일 파일 기본 변환 흐름을 검증.
 - [ ] **`image` 0.25 업그레이드** — 10-bit AVIF 디코딩 지원. breaking change 가 있어 별도 작업. 업그레이드 후 ravif 의 8-bit 강제도 풀어줄 수 있음
 - [ ] **PDF 입력** — 첫 페이지만 렌더링할지, 페이지 범위를 여러 파일로 내보낼지, 기본 DPI를 어떻게 둘지 먼저 정해야 하는 별도 기능.
 - [ ] **HEIC 입력** — `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트. 부담 큼.
-- [ ] **대화형 모드 통합 테스트** — `dialoguer::Select` 가 PTY 필요해서 `rexpect` 등 도입 부담. 우선순위 낮음 (위 리팩토링으로 검증/경로 로직은 단위 테스트로 커버됨).
+- [ ] **대화형 모드 추가 PTY 시나리오** — 배치 모드, JPEG 배경색 직접 입력, 리사이즈 적용 흐름은 필요 시 추가.
 
 ## 환경 메모
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,6 +16,8 @@ src/
     test_utils.rs # 테스트 헬퍼 함수 및 매크로
     unit_tests.rs # 단위 테스트
     integration_tests.rs # 통합 테스트
+tests/
+  interactive_cli.rs # rexpect 기반 대화형 CLI PTY 통합 테스트
 ```
 
 ## 테스트 실행 방법
@@ -303,6 +305,14 @@ cargo test --release
     - `#RRGGBB` 와 `RRGGBB` 입력을 JPEG 배경색으로 파싱하는지 확인
     - 잘못된 색상 입력을 거부하고, 흰색/검정/직접 입력 선택지 매핑을 검증
 
+### 🖥️ 대화형 CLI PTY 통합 테스트 (`tests/interactive_cli.rs`)
+
+45. **`interactive_default_single_file_flow_converts_to_webp`**
+    - 인자 없이 실행한 실제 바이너리를 `rexpect` PTY 세션에서 조작
+    - 기본 선택지 흐름(이미지 1개 변환 → WebP → 웹 권장 품질 → 리사이즈 안 함 → 기본 출력 경로)으로 PNG 를 WebP 로 변환하는지 확인
+    - 출력 파일 생성과 WebP 시그니처(`RIFF` / `WEBP`)를 검증
+    - `rexpect` 는 PTY 출력을 byte 단위 문자로 읽기 때문에 테스트 안에서 한국어 프롬프트 기대 문자열을 같은 방식으로 변환해 매칭
+
 ## 테스트 매크로
 
 ### `test_description!`
@@ -361,7 +371,7 @@ fn test_new_feature() {
 
 ## 테스트 커버리지
 
-현재 테스트는 다음 영역을 커버합니다 (총 72개):
+현재 테스트는 다음 영역을 커버합니다 (총 73개):
 - ✅ 파일 크기 포맷팅
 - ✅ 출력 요약 라벨 (PNG 무손실 / 손실 포맷 품질 표시)
 - ✅ 출력 포맷별 허용 확장자 매칭
@@ -384,10 +394,11 @@ fn test_new_feature() {
 - ✅ JPG/JPEG 단일 입력 (jpeg→webp, jpeg→png, .jpg 확장자 별칭)
 - ✅ CLI 인자 파서 (`--quality` 1.0~100.0 범위, `--threads` ≥ 1 검증, 출력 포맷 허용값 검증, 대화형 기본 실행, 비대화형 필수 인자 검증)
 - ✅ 대화형 모드 검증 클로저 + 디폴트 출력 경로 빌더 (순수 함수로 분리하여 단위 테스트)
+- ✅ 대화형 CLI PTY 통합 테스트 (인자 없는 실행의 단일 파일 기본 변환 흐름)
 
 향후 추가할 수 있는 테스트:
 - 10-bit AVIF 입력 디코딩 (`image` 0.25 업그레이드 후)
 - 일괄 변환 중 일부 파일이 손상되어 실패할 때의 동작
 - 대용량 이미지 처리
 - 메모리 사용량 테스트
-- 대화형 모드 통합 테스트 (`dialoguer::Select` 는 PTY 필요 — `rexpect` 등 도입 필요)
+- 대화형 모드 추가 PTY 시나리오 (배치 모드, JPEG 배경색 직접 입력, 리사이즈 적용)

--- a/tests/interactive_cli.rs
+++ b/tests/interactive_cli.rs
@@ -1,0 +1,71 @@
+#[cfg(unix)]
+mod unix {
+    use image::{ImageBuffer, Rgb};
+    use rexpect::session::{spawn_command, PtySession};
+    use std::error::Error;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn create_test_image(path: &std::path::Path) -> Result<(), Box<dyn Error>> {
+        let img = ImageBuffer::from_fn(32, 32, |x, y| {
+            if (x + y) % 2 == 0 {
+                Rgb([255u8, 255u8, 255u8])
+            } else {
+                Rgb([0u8, 0u8, 0u8])
+            }
+        });
+        img.save(path)?;
+        Ok(())
+    }
+
+    fn pty_text(text: &str) -> String {
+        text.as_bytes().iter().map(|byte| *byte as char).collect()
+    }
+
+    fn expect_text(session: &mut PtySession, text: &str) -> Result<(), rexpect::error::Error> {
+        session.exp_string(&pty_text(text)).map(|_| ())
+    }
+
+    #[test]
+    fn interactive_default_single_file_flow_converts_to_webp() -> Result<(), Box<dyn Error>> {
+        let temp_dir = TempDir::new()?;
+        let input_path = temp_dir.path().join("sample.png");
+        let output_path = temp_dir.path().join("sample.webp");
+        create_test_image(&input_path)?;
+
+        let mut command = Command::new(env!("CARGO_BIN_EXE_image_converter"));
+        command.env("NO_COLOR", "1");
+        let mut session = spawn_command(command, Some(20_000))?;
+
+        expect_text(&mut session, "이미지 변환기 - 대화형 모드")?;
+        expect_text(&mut session, "무엇을 변환할까요?")?;
+        session.send_line("")?;
+
+        expect_text(&mut session, "변환할 이미지 파일 경로")?;
+        session.send_line(input_path.to_str().expect("테스트 경로는 UTF-8"))?;
+
+        expect_text(&mut session, "어떤 형식으로 저장할까요?")?;
+        session.send_line("")?;
+
+        expect_text(&mut session, "품질을 선택하세요")?;
+        session.send_line("")?;
+
+        expect_text(&mut session, "가로 크기를 줄일까요?")?;
+        session.send_line("")?;
+
+        expect_text(&mut session, "저장할 파일 경로")?;
+        session.send_line("")?;
+
+        expect_text(&mut session, "변환 완료")?;
+        session.exp_eof()?;
+
+        assert!(output_path.exists(), "기본 출력 WebP 파일이 생성되어야 함");
+        let output = std::fs::read(&output_path)?;
+        assert!(
+            output.starts_with(b"RIFF") && output.get(8..12) == Some(b"WEBP"),
+            "출력 파일은 WebP 시그니처를 가져야 함"
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
- rexpect 기반 PTY 테스트로 실제 바이너리의 대화형 기본 흐름을 검증
- Unix 전용 dev-dependency를 추가하고 lock 파일을 갱신
- 테스트 문서와 작업 메모리에 PTY 통합 테스트 범위를 반영