### PR TITLE
feat: 비대화형 CLI 변환 옵션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 - **용량 비교**: 변환 전후 파일 크기 및 감소율 표시 (배치 모드는 합계까지)
 - **진행 상황 표시**: 실시간 진행률 표시
 - **품질 설정**: 1-100% 품질 조정 가능 (PNG 는 무손실이라 자동 무시)
-- **대화형 리사이즈**: 최대 가로 크기를 지정하면 비율을 유지하며 축소 (확대 없음)
-- **JPEG 배경색 선택**: 투명 PNG/WebP 를 JPEG 로 바꿀 때 흰색/검정/#RRGGBB 배경으로 합성
+- **리사이즈**: 최대 가로 크기를 지정하면 비율을 유지하며 축소 (확대 없음)
+- **JPEG 배경색 지정**: 투명 PNG/WebP 를 JPEG 로 바꿀 때 흰색/검정/#RRGGBB 배경으로 합성
 - **덮어쓰기 방지**: 기존 출력 파일을 보존 (단일 변환은 중단, 일괄 변환은 해당 파일 건너뜀)
 - **출력 확장자 검증**: 선택한 출력 형식과 파일 확장자가 다르면 변환 전 차단
 - **아름다운 UI**: 이모티콘과 색상으로 보기 좋은 출력
@@ -167,6 +167,12 @@ JPEG 출력에서는 투명 PNG/WebP 의 투명 영역을 배경색 위에 합�
 # JPEG 로 변환 (알파 채널이 있으면 자동 RGB 변환)
 ./target/release/image_converter -i icon.png -o icon.jpg -f jpeg -q 85
 
+# 최대 가로 크기를 1600px 로 축소 (원본보다 작을 때만 적용)
+./target/release/image_converter -i hero.png -o hero.webp -f webp --max-width 1600
+
+# JPEG 변환 시 투명 영역을 검정 배경으로 합성
+./target/release/image_converter -i logo.png -o logo.jpg -f jpg --jpeg-background black
+
 # TIFF/BMP 입력도 그대로 지원
 ./target/release/image_converter -i scan.tiff -o scan.webp -f webp -q 85
 ```
@@ -187,6 +193,12 @@ JPEG 출력에서는 투명 PNG/WebP 의 투명 영역을 배경색 위에 합�
 # 사용할 스레드 수 제한 (CLI 플래그)
 ./target/release/image_converter -i photos -o photos_webp -f webp -r -t 4
 
+# 폴더 전체 이미지를 최대 1200px 가로로 줄이며 변환
+./target/release/image_converter -i photos -o photos_webp -f webp -r --max-width 1200
+
+# 투명 이미지들을 JPEG 로 만들 때 흰색 배경으로 합성
+./target/release/image_converter -i icons -o icons_jpg -f jpeg -r --jpeg-background '#ffffff'
+
 # 환경변수로도 가능 (CLI 플래그가 우선)
 RAYON_NUM_THREADS=4 ./target/release/image_converter -i photos -o photos_webp -f webp -r
 ```
@@ -200,6 +212,8 @@ RAYON_NUM_THREADS=4 ./target/release/image_converter -i photos -o photos_webp -f
 - `-q, --quality <QUALITY>`: 변환 품질 1-100 (기본값: 90, **PNG 출력 시 무손실이라 무시됨**)
 - `-r, --recursive`: 디렉토리 입력 시 하위 폴더까지 재귀 변환
 - `-t, --threads <N>`: 디렉토리 모드에서 사용할 스레드 수 (1 이상, 미지정 시 `RAYON_NUM_THREADS` 또는 CPU 코어 수). 단일 파일 변환에는 영향 없음
+- `--max-width <PX>`: 최대 가로 크기. 원본보다 작을 때만 비율을 유지하며 축소
+- `--jpeg-background <COLOR>`: JPEG/JPG 출력 시 투명 영역 배경색 (`white`, `black`, `#RRGGBB`)
 
 ## 💡 예제 출력
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,7 @@ image_converter/
 - 인자 없는 실행 또는 `-I/--interactive` 는 대화형 모드로 분기 (기본 UX)
 - 명령줄 모드는 자동화/반복 작업용이며 `-i/--input`, `-o/--output`, `-f/--format` 을 명시적으로 요구
 - 입력 경로 타입(파일/디렉토리)에 따라 단일/일괄 변환 분기
+- 자동화용 옵션으로 최대 가로 크기(`--max-width`) 와 JPEG 배경색(`--jpeg-background`) 을 받아 `ConversionOptions` 로 전달
 - 에러 처리 및 종료 — `ConverterError` 의 `Display` 로 메시지 출력
 
 ### `error.rs` (에러 타입)
@@ -76,7 +77,7 @@ image_converter/
 - `convert_image_with_conversion_options` / `convert_image_silent_with_conversion_options`: `ConversionOptions` 로 리사이즈와 JPEG 배경색을 함께 전달할 때 사용
 - 두 함수 모두 동일한 내부 인코딩 헬퍼를 호출 (코드 중복 제거)
 - 리사이즈 옵션은 인코딩 전에 적용하며, 최대 가로 크기보다 큰 이미지만 비율 유지 축소 (`Lanczos3`, 확대 없음)
-- JPEG 배경색 옵션은 JPEG 인코딩 직전에 적용하며, 기본 API 에서는 기존 동작을 유지하고 대화형 모드에서만 값을 질문
+- JPEG 배경색 옵션은 JPEG 인코딩 직전에 적용하며, 기본 API 에서는 기존 동작을 유지하고 대화형 모드/CLI 옵션에서만 값을 전달
 - `ConvertStats` 는 원본 크기와 출력 크기를 함께 담아 단일 변환 요약에서 리사이즈 결과를 표시할 수 있음
 - 단일 변환은 출력 파일 확장자가 선택 포맷과 다르면 인코딩 전에 `OutputExtensionMismatch` 로 중단
 - 출력 파일은 `create_new` 방식으로 생성하여 기존 파일을 덮어쓰지 않음. 이미 있으면 `OutputExists` 에러 반환
@@ -125,6 +126,7 @@ image_converter/
 - 테스트 유틸리티 및 매크로
 - 깔끔한 테스트 출력
 - 루트 `tests/interactive_cli.rs` 는 `rexpect` 로 실제 PTY 에서 바이너리를 실행해 `dialoguer` 기반 대화형 흐름을 검증
+- 같은 파일에서 비대화형 CLI 의 `--max-width`, `--jpeg-background` 옵션도 실제 바이너리 실행으로 검증
 
 ### Docker 개발 환경
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,6 +12,20 @@
 
 ## 최근 작업 로그
 
+### 2026-05-03 — 비대화형 CLI 변환 옵션 추가
+
+- 자동화용 명령줄 모드에 `--max-width <PX>` 옵션 추가
+  - 단일 파일과 폴더 전체 변환 모두에서 기존 `ResizeOptions` 로 연결
+  - 1 이상의 픽셀 값만 허용하고, 원본보다 작을 때만 비율 유지 축소
+- 자동화용 명령줄 모드에 `--jpeg-background <COLOR>` 옵션 추가
+  - `white`, `black`, `#RRGGBB` 입력 지원
+  - JPG/JPEG 출력에서만 허용하고 다른 출력 포맷에서는 clap 검증 에러로 차단
+- `JpegBackground::from_hex` 헬퍼를 추가해 대화형/CLI 색상 파싱을 공유
+- 실제 바이너리 통합 테스트 2개 추가
+  - `non_interactive_cli_applies_max_width`
+  - `non_interactive_cli_applies_jpeg_background`
+- README / docs/architecture.md / docs/testing.md 갱신
+
 ### 2026-05-01 — 대화형 CLI PTY 통합 테스트 추가
 
 - `rexpect = "0.7.0"` 을 Unix 전용 dev-dependency 로 추가
@@ -397,6 +411,7 @@
 - [x] **JPEG 배경색 옵션** — 완료. 대화형 JPEG 출력에서 투명 영역 배경색을 선택하고, 인코딩 전 알파 합성을 적용. 72 테스트 통과.
 - [x] **2.5.0 릴리즈 준비** — 완료. 버전 bump + 릴리즈 노트 추가.
 - [x] **대화형 모드 통합 테스트** — 완료. `rexpect` PTY 테스트로 인자 없는 단일 파일 기본 변환 흐름을 검증.
+- [x] **비대화형 CLI 변환 옵션** — 완료. `--max-width`, `--jpeg-background` 를 자동화용 CLI 에 추가하고 실제 바이너리 통합 테스트로 검증.
 - [ ] **`image` 0.25 업그레이드** — 10-bit AVIF 디코딩 지원. breaking change 가 있어 별도 작업. 업그레이드 후 ravif 의 8-bit 강제도 풀어줄 수 있음
 - [ ] **PDF 입력** — 첫 페이지만 렌더링할지, 페이지 범위를 여러 파일로 내보낼지, 기본 DPI를 어떻게 둘지 먼저 정해야 하는 별도 기능.
 - [ ] **HEIC 입력** — `libheif` 시스템 의존성 + `libheif-rs` 등 외부 크레이트. 부담 큼.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,7 +17,7 @@ src/
     unit_tests.rs # 단위 테스트
     integration_tests.rs # 통합 테스트
 tests/
-  interactive_cli.rs # rexpect 기반 대화형 CLI PTY 통합 테스트
+  interactive_cli.rs # rexpect 기반 대화형 CLI PTY + 비대화형 CLI 통합 테스트
 ```
 
 ## 테스트 실행 방법
@@ -259,59 +259,76 @@ cargo test --release
 32. **`parse_threads_rejects_non_numeric`**
     - 비숫자(`"abc"`) 와 음수(`"-1"`) 입력 거부 확인
 
-33. **`parse_format_accepts_valid_values_case_insensitive`**
+33. **`parse_max_width_*`** (2개)
+    - `--max-width` 가 1 이상의 픽셀 값을 통과시키고, 0 / 음수 / 비숫자 입력을 거부하는지 확인
+
+34. **`parse_jpeg_background_*`** (2개)
+    - `--jpeg-background` 가 `white`, `black`, `#RRGGBB` 값을 파싱하고 잘못된 색상 입력을 거부하는지 확인
+
+35. **`build_conversion_options_*`** (2개)
+    - CLI 의 `--max-width`, `--jpeg-background` 값을 `ConversionOptions` 로 매핑하는지 확인
+    - JPEG 배경색 옵션이 JPG/JPEG 출력에서만 허용되는지 확인
+
+36. **`parse_format_accepts_valid_values_case_insensitive`**
     - `--format WEBP` 처럼 대문자로 입력해도 `OutputFormat::Webp` 로 파싱되는지 확인
 
-34. **`parse_format_rejects_invalid_value`**
+37. **`parse_format_rejects_invalid_value`**
     - `--format xyz` 같은 미지원 출력 포맷을 clap 단계에서 거부하는지 확인
 
-35. **대화형 기본 실행 / 비대화형 필수 인자 테스트** (4개)
+38. **대화형 기본 실행 / 비대화형 필수 인자/옵션 테스트** (5개)
     - 인자 없이 실행하는 파싱 결과가 대화형 기본 실행으로 분기되는지 확인
     - `-I` 플래그가 입력/출력/포맷 없이도 대화형 모드로 분기되는지 확인
     - 비대화형 모드에서 `-i`/`-o`/`-f` 누락 목록을 올바르게 계산하는지 확인
     - `-i`/`-o`/`-f` 가 모두 있으면 누락 인자가 없는지 확인
+    - 비대화형 모드에서 `--max-width`, `--jpeg-background` 값을 함께 파싱하는지 확인
 
 ### 🎯 대화형 모드 검증 단위 테스트 (`src/interactive.rs`)
 
-36. **`validate_input_path_*`** (4개)
+39. **`validate_input_path_*`** (4개)
     - 존재하지 않는 경로 거부, 단일 모드에 디렉토리 입력 거부, 배치 모드에 파일 입력 거부, 정상 케이스(파일/디렉토리) 통과
 
-37. **`validate_quality_input_*`** (2개)
+40. **`validate_quality_input_*`** (2개)
     - 1.0/50.5/100.0 정상 범위 통과, 0 / 0.99 / 100.01 / -10 / `"abc"` 거부
 
-38. **`quality_options` / `quality_for_selection`** (2개)
+41. **`quality_options` / `quality_for_selection`** (2개)
     - 웹 권장(90%) 프리셋이 기본 선택지로 앞에 오는지 확인
     - 품질 선택지 순서가 실제 품질 값(90/80/70/100/직접 입력)으로 매핑되는지 확인
 
-39. **`validate_threads_input_*`** (2개)
+42. **`validate_threads_input_*`** (2개)
     - 1, 16 통과, 0 / -1 / `"abc"` / 빈 입력 거부
 
-40. **`validate_resize_width_input_*`** (2개)
+43. **`validate_resize_width_input_*`** (2개)
     - 1 이상의 픽셀 값만 허용하고, 0 / 음수 / 비숫자 / 빈 입력은 거부
 
-41. **`validate_output_file_path_*`** (3개)
+44. **`validate_output_file_path_*`** (3개)
     - 선택 포맷과 출력 파일 확장자가 일치하는지 검증
     - JPEG 는 `.jpg`/`.jpeg` 별칭을 모두 허용하고, 불일치/확장자 없음은 거부
 
-42. **`default_output_path_for_file_*`** (5개)
+45. **`default_output_path_for_file_*`** (5개)
     - 입력 파일과 같은 디렉토리에서 확장자만 바꾼 기본값 제안 (예: `photo.png` + webp → `photo.webp`)
     - 자연스러운 기본 출력 경로가 이미 있으면 `_converted`, `_converted_2` 순서로 충돌 회피
     - 확장자 없는 입력 (`no_ext` + png → `no_ext.png`) 처리
 
-43. **`default_output_path_for_dir_*`** (2개)
+46. **`default_output_path_for_dir_*`** (2개)
     - `{dirname}_converted_{format}` 패턴 (예: `photos` + webp → `photos_converted_webp`), trailing slash (`/tmp/photos/`) 정상 처리
 
-44. **`parse_hex_color_*` / `jpeg_background_options_map_defaults`** (3개)
+47. **`parse_hex_color_*` / `jpeg_background_options_map_defaults`** (3개)
     - `#RRGGBB` 와 `RRGGBB` 입력을 JPEG 배경색으로 파싱하는지 확인
     - 잘못된 색상 입력을 거부하고, 흰색/검정/직접 입력 선택지 매핑을 검증
 
 ### 🖥️ 대화형 CLI PTY 통합 테스트 (`tests/interactive_cli.rs`)
 
-45. **`interactive_default_single_file_flow_converts_to_webp`**
+48. **`interactive_default_single_file_flow_converts_to_webp`**
     - 인자 없이 실행한 실제 바이너리를 `rexpect` PTY 세션에서 조작
     - 기본 선택지 흐름(이미지 1개 변환 → WebP → 웹 권장 품질 → 리사이즈 안 함 → 기본 출력 경로)으로 PNG 를 WebP 로 변환하는지 확인
     - 출력 파일 생성과 WebP 시그니처(`RIFF` / `WEBP`)를 검증
     - `rexpect` 는 PTY 출력을 byte 단위 문자로 읽기 때문에 테스트 안에서 한국어 프롬프트 기대 문자열을 같은 방식으로 변환해 매칭
+
+49. **`non_interactive_cli_applies_max_width`**
+    - 실제 바이너리에 `--max-width` 를 전달해 PNG 출력 크기가 축소되는지 확인
+
+50. **`non_interactive_cli_applies_jpeg_background`**
+    - 실제 바이너리에 `--jpeg-background black` 을 전달해 투명 PNG 가 검정 배경 JPEG 로 합성되는지 확인
 
 ## 테스트 매크로
 
@@ -371,7 +388,7 @@ fn test_new_feature() {
 
 ## 테스트 커버리지
 
-현재 테스트는 다음 영역을 커버합니다 (총 73개):
+현재 테스트는 다음 영역을 커버합니다 (총 82개):
 - ✅ 파일 크기 포맷팅
 - ✅ 출력 요약 라벨 (PNG 무손실 / 손실 포맷 품질 표시)
 - ✅ 출력 포맷별 허용 확장자 매칭
@@ -392,9 +409,10 @@ fn test_new_feature() {
 - ✅ 혼합 입력 포맷 일괄 변환 (PNG + WebP + AVIF + TIFF + BMP → PNG)
 - ✅ 명시적 스레드 수 옵션 (`threads=None` vs `threads=Some(1)` 결과 일관성)
 - ✅ JPG/JPEG 단일 입력 (jpeg→webp, jpeg→png, .jpg 확장자 별칭)
-- ✅ CLI 인자 파서 (`--quality` 1.0~100.0 범위, `--threads` ≥ 1 검증, 출력 포맷 허용값 검증, 대화형 기본 실행, 비대화형 필수 인자 검증)
+- ✅ CLI 인자 파서 (`--quality` 1.0~100.0 범위, `--threads` ≥ 1, `--max-width` ≥ 1, `--jpeg-background`, 출력 포맷 허용값, 대화형 기본 실행, 비대화형 필수 인자 검증)
 - ✅ 대화형 모드 검증 클로저 + 디폴트 출력 경로 빌더 (순수 함수로 분리하여 단위 테스트)
 - ✅ 대화형 CLI PTY 통합 테스트 (인자 없는 실행의 단일 파일 기본 변환 흐름)
+- ✅ 비대화형 CLI 통합 테스트 (`--max-width`, `--jpeg-background` 실제 바이너리 흐름)
 
 향후 추가할 수 있는 테스트:
 - 10-bit AVIF 입력 디코딩 (`image` 0.25 업그레이드 후)

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -49,6 +49,22 @@ impl JpegBackground {
     pub const fn black() -> Self {
         Self { r: 0, g: 0, b: 0 }
     }
+
+    pub fn from_hex(input: &str) -> std::result::Result<Self, String> {
+        let trimmed = input.trim();
+        let trimmed = trimmed.strip_prefix('#').unwrap_or(trimmed);
+        if trimmed.len() != 6 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err("#RRGGBB 형식으로 입력하세요".to_string());
+        }
+
+        let r =
+            u8::from_str_radix(&trimmed[0..2], 16).map_err(|_| "빨간색 값을 읽을 수 없습니다")?;
+        let g =
+            u8::from_str_radix(&trimmed[2..4], 16).map_err(|_| "초록색 값을 읽을 수 없습니다")?;
+        let b =
+            u8::from_str_radix(&trimmed[4..6], 16).map_err(|_| "파란색 값을 읽을 수 없습니다")?;
+        Ok(Self { r, g, b })
+    }
 }
 
 /// 변환 전후에 적용할 추가 옵션

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -45,16 +45,7 @@ fn validate_resize_width_input(input: &str) -> Result<(), &'static str> {
 }
 
 fn parse_hex_color(input: &str) -> Result<JpegBackground, String> {
-    let trimmed = input.trim();
-    let trimmed = trimmed.strip_prefix('#').unwrap_or(trimmed);
-    if trimmed.len() != 6 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err("#RRGGBB 형식으로 입력하세요".to_string());
-    }
-
-    let r = u8::from_str_radix(&trimmed[0..2], 16).map_err(|_| "빨간색 값을 읽을 수 없습니다")?;
-    let g = u8::from_str_radix(&trimmed[2..4], 16).map_err(|_| "초록색 값을 읽을 수 없습니다")?;
-    let b = u8::from_str_radix(&trimmed[4..6], 16).map_err(|_| "파란색 값을 읽을 수 없습니다")?;
-    Ok(JpegBackground { r, g, b })
+    JpegBackground::from_hex(input)
 }
 
 fn validate_output_file_path(input: &str, format: OutputFormat) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@ use colored::*;
 use std::path::Path;
 
 use image_converter::{
-    convert_directory, convert_image, interactive::interactive_mode, OutputFormat,
+    convert_directory_with_conversion_options, convert_image_with_conversion_options,
+    interactive::interactive_mode, ConversionOptions, JpegBackground, OutputFormat, ResizeOptions,
 };
 
 fn parse_quality(s: &str) -> Result<f32, String> {
@@ -24,6 +25,39 @@ fn parse_threads(s: &str) -> Result<usize, String> {
         return Err("스레드 수는 1 이상이어야 합니다".into());
     }
     Ok(n)
+}
+
+fn parse_max_width(s: &str) -> Result<u32, String> {
+    let n: u32 = s
+        .parse()
+        .map_err(|_| format!("'{s}' 는 유효한 픽셀 값이 아닙니다"))?;
+    if n == 0 {
+        return Err("최대 가로 크기는 1 이상이어야 합니다".into());
+    }
+    Ok(n)
+}
+
+fn parse_jpeg_background(s: &str) -> Result<JpegBackground, String> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "white" => Ok(JpegBackground::white()),
+        "black" => Ok(JpegBackground::black()),
+        _ => JpegBackground::from_hex(s),
+    }
+}
+
+fn build_conversion_options(
+    format: OutputFormat,
+    max_width: Option<u32>,
+    jpeg_background: Option<JpegBackground>,
+) -> Result<ConversionOptions, String> {
+    if jpeg_background.is_some() && !format.is_jpeg() {
+        return Err("--jpeg-background 옵션은 JPG/JPEG 출력에서만 사용할 수 있습니다".into());
+    }
+
+    Ok(ConversionOptions {
+        resize: max_width.map(|max_width| ResizeOptions { max_width }),
+        jpeg_background,
+    })
 }
 
 /// 대화형 안내로 웹용 이미지를 PNG/JPG/WebP/AVIF 로 변환합니다
@@ -62,6 +96,14 @@ struct Cli {
     /// 디렉토리 모드에서 사용할 스레드 수 (1 이상, 미지정 시 RAYON_NUM_THREADS 또는 CPU 코어 수)
     #[arg(short, long, value_name = "N", value_parser = parse_threads)]
     threads: Option<usize>,
+
+    /// 최대 가로 크기(px). 원본보다 작을 때만 비율 유지 축소
+    #[arg(long, value_name = "PX", value_parser = parse_max_width)]
+    max_width: Option<u32>,
+
+    /// JPEG 출력 시 투명 영역 배경색 (white, black, #RRGGBB)
+    #[arg(long, value_name = "COLOR", value_parser = parse_jpeg_background)]
+    jpeg_background: Option<JpegBackground>,
 }
 
 fn should_enter_interactive(cli: &Cli, invoked_without_args: bool) -> bool {
@@ -105,19 +147,33 @@ fn main() {
         let input = cli.input.expect("input은 비대화형 모드에서 필수입니다");
         let output = cli.output.expect("output은 비대화형 모드에서 필수입니다");
         let format = cli.format.expect("format은 비대화형 모드에서 필수입니다");
+        let conversion_options =
+            match build_conversion_options(format, cli.max_width, cli.jpeg_background) {
+                Ok(options) => options,
+                Err(message) => Cli::command()
+                    .error(ErrorKind::ValueValidation, message)
+                    .exit(),
+            };
 
         if Path::new(&input).is_dir() {
-            convert_directory(
+            convert_directory_with_conversion_options(
                 &input,
                 &output,
                 format,
                 cli.quality,
                 cli.recursive,
                 cli.threads,
+                conversion_options,
             )
             .map(|_| ())
         } else {
-            convert_image(&input, &output, format, cli.quality)
+            convert_image_with_conversion_options(
+                &input,
+                &output,
+                format,
+                cli.quality,
+                conversion_options,
+            )
         }
     };
 
@@ -169,6 +225,65 @@ mod tests {
     fn parse_threads_rejects_non_numeric() {
         assert!(parse_threads("abc").is_err());
         assert!(parse_threads("-1").is_err());
+    }
+
+    #[test]
+    fn parse_max_width_accepts_positive_pixels() {
+        assert_eq!(parse_max_width("1").unwrap(), 1);
+        assert_eq!(parse_max_width("1600").unwrap(), 1600);
+    }
+
+    #[test]
+    fn parse_max_width_rejects_invalid_values() {
+        assert!(parse_max_width("0").is_err());
+        assert!(parse_max_width("-1").is_err());
+        assert!(parse_max_width("abc").is_err());
+    }
+
+    #[test]
+    fn parse_jpeg_background_accepts_named_and_hex_values() {
+        assert_eq!(
+            parse_jpeg_background("white").unwrap(),
+            JpegBackground::white()
+        );
+        assert_eq!(
+            parse_jpeg_background("BLACK").unwrap(),
+            JpegBackground::black()
+        );
+        assert_eq!(
+            parse_jpeg_background("#1A2b3C").unwrap(),
+            JpegBackground {
+                r: 0x1A,
+                g: 0x2B,
+                b: 0x3C,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_jpeg_background_rejects_invalid_values() {
+        assert!(parse_jpeg_background("#fff").is_err());
+        assert!(parse_jpeg_background("blue").is_err());
+    }
+
+    #[test]
+    fn build_conversion_options_maps_cli_values() {
+        let options = build_conversion_options(
+            OutputFormat::Jpeg,
+            Some(1200),
+            Some(JpegBackground::black()),
+        )
+        .unwrap();
+
+        assert_eq!(options.resize, Some(ResizeOptions { max_width: 1200 }));
+        assert_eq!(options.jpeg_background, Some(JpegBackground::black()));
+    }
+
+    #[test]
+    fn build_conversion_options_rejects_jpeg_background_for_non_jpeg() {
+        let err = build_conversion_options(OutputFormat::Webp, None, Some(JpegBackground::white()))
+            .unwrap_err();
+        assert!(err.contains("JPG/JPEG 출력"));
     }
 
     #[test]
@@ -240,5 +355,26 @@ mod tests {
         .unwrap();
         assert!(!should_enter_interactive(&cli, false));
         assert!(missing_non_interactive_args(&cli).is_empty());
+    }
+
+    #[test]
+    fn non_interactive_mode_parses_conversion_options() {
+        let cli = Cli::try_parse_from([
+            "image_converter",
+            "-i",
+            "input.png",
+            "-o",
+            "output.jpg",
+            "-f",
+            "jpeg",
+            "--max-width",
+            "800",
+            "--jpeg-background",
+            "#ffffff",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.max_width, Some(800));
+        assert_eq!(cli.jpeg_background, Some(JpegBackground::white()));
     }
 }

--- a/tests/interactive_cli.rs
+++ b/tests/interactive_cli.rs
@@ -1,9 +1,9 @@
 #[cfg(unix)]
 mod unix {
-    use image::{ImageBuffer, Rgb};
+    use image::{GenericImageView, ImageBuffer, Rgb, Rgba, RgbaImage};
     use rexpect::session::{spawn_command, PtySession};
     use std::error::Error;
-    use std::process::Command;
+    use std::process::{Command, Stdio};
     use tempfile::TempDir;
 
     fn create_test_image(path: &std::path::Path) -> Result<(), Box<dyn Error>> {
@@ -64,6 +64,77 @@ mod unix {
         assert!(
             output.starts_with(b"RIFF") && output.get(8..12) == Some(b"WEBP"),
             "출력 파일은 WebP 시그니처를 가져야 함"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn non_interactive_cli_applies_max_width() -> Result<(), Box<dyn Error>> {
+        let temp_dir = TempDir::new()?;
+        let input_path = temp_dir.path().join("wide.png");
+        let output_path = temp_dir.path().join("wide.png.out.png");
+        create_test_image(&input_path)?;
+
+        let status = Command::new(env!("CARGO_BIN_EXE_image_converter"))
+            .args([
+                "-i",
+                input_path.to_str().expect("테스트 경로는 UTF-8"),
+                "-o",
+                output_path.to_str().expect("테스트 경로는 UTF-8"),
+                "-f",
+                "png",
+                "--max-width",
+                "16",
+            ])
+            .env("NO_COLOR", "1")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()?;
+
+        assert!(status.success(), "CLI 변환이 성공해야 함");
+        let output = image::open(&output_path)?;
+        assert_eq!(output.dimensions(), (16, 16));
+
+        Ok(())
+    }
+
+    #[test]
+    fn non_interactive_cli_applies_jpeg_background() -> Result<(), Box<dyn Error>> {
+        let temp_dir = TempDir::new()?;
+        let input_path = temp_dir.path().join("transparent.png");
+        let output_path = temp_dir.path().join("transparent.jpg");
+        let mut rgba = RgbaImage::new(16, 16);
+        for pixel in rgba.pixels_mut() {
+            *pixel = Rgba([255, 0, 0, 0]);
+        }
+        rgba.save(&input_path)?;
+
+        let status = Command::new(env!("CARGO_BIN_EXE_image_converter"))
+            .args([
+                "-i",
+                input_path.to_str().expect("테스트 경로는 UTF-8"),
+                "-o",
+                output_path.to_str().expect("테스트 경로는 UTF-8"),
+                "-f",
+                "jpeg",
+                "-q",
+                "100",
+                "--jpeg-background",
+                "black",
+            ])
+            .env("NO_COLOR", "1")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()?;
+
+        assert!(status.success(), "CLI 변환이 성공해야 함");
+        let output = image::open(&output_path)?.to_rgb8();
+        let pixel = output.get_pixel(0, 0);
+        assert!(
+            pixel[0] < 15 && pixel[1] < 15 && pixel[2] < 15,
+            "투명 영역이 검정 배경에 가깝게 합성되어야 함: {:?}",
+            pixel
         );
 
         Ok(())


### PR DESCRIPTION
- 자동화용 명령줄 모드에 --max-width 와 --jpeg-background 옵션을 추가

- 기존 ConversionOptions 를 재사용해 단일/일괄 변환에 리사이즈와 JPEG 배경색을 전달

- 실제 바이너리 통합 테스트와 관련 문서를 갱신