### PR TITLE
docs: 웹 서비스 확장 계획 정리

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - `testing.md`: Docker/로컬 테스트 실행법, 테스트 목록, 테스트 유틸리티
 - `release-notes.md`: 버전별 주요 변경 사항과 지원 범위
 - `releasing.md`: 배포 전 체크리스트, Docker 실행, 로컬 설치 경로
+- `web-service-plan.md`: Next.js 웹 서비스 확장, Cloud Run 배포, UI 시스템 계획
 - `memory.md`: 최근 작업 로그, 결정 기록, 진행/대기 항목
 
 ## 문서 관리 규칙

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,6 +12,19 @@
 
 ## 최근 작업 로그
 
+### 2026-05-03 — 웹 서비스 확장 계획 정리
+
+- `docs/web-service-plan.md` 추가
+  - CLI 유지 + Rust 변환 코어 재사용 + Next.js 웹 앱 + Rust API 서버 확장 방향 정리
+  - Next.js 는 화면과 인증 흐름을 담당하고, 이미지 파일은 Cloud Run 의 Rust API 로 직접 업로드하는 구조를 명시
+  - Vercel Function 을 이미지 파일 프록시 경로로 쓰지 않는 이유를 payload 제한 관점에서 정리
+  - UI 시스템은 여러 라이브러리 혼합 대신 Tailwind CSS + shadcn/ui 단일 기준으로 확정
+  - shadcn/ui 는 기본 흑백 예제를 그대로 쓰지 않고, 제품용 design token 과 변환 도구 UX 를 직접 설계하는 출발점으로 사용하기로 정리
+  - HeroUI 는 기본 스타일은 좋지만 유료 Pro 영역과 테마 의존성을 고려해 MVP 기본값에서 제외
+  - Magic UI / Aceternity UI / TailAdmin 은 기본 UI 시스템이 아니라 참고용 또는 향후 별도 검토 후보로 분리
+  - Cloud Run, Render, AWS App Runner/Fargate/Lightsail 관점의 초기 배포 판단과 수익화 확장 경로 정리
+- docs/README.md 에 웹 서비스 확장 계획 문서 링크 추가
+
 ### 2026-05-03 — 배포/설치 경험 정리
 
 - `docs/releasing.md` 추가 — 로컬 Docker 검증 후 push 하는 흐름, Docker 실행, 로컬 설치, release 빌드/태그 체크리스트 정리

--- a/docs/web-service-plan.md
+++ b/docs/web-service-plan.md
@@ -1,0 +1,264 @@
+# 웹 서비스 확장 계획
+
+현재 Rust CLI 는 유지하면서, 같은 변환 코어를 웹 서비스에서도 재사용하기 위한 설계 메모입니다. 목표는 처음부터 큰 SaaS 를 만드는 것이 아니라, 실제로 쓸 수 있는 고품질 단일 이미지 변환 웹 도구를 먼저 만들고 이후 로그인, 사용량 제한, 결제, 배치 변환으로 확장할 수 있는 길을 열어두는 것입니다.
+
+## 기본 판단
+
+- CLI 는 계속 유지한다.
+- 변환 로직은 Rust 라이브러리 API 를 중심으로 재사용한다.
+- 웹 UI 는 Next.js + TypeScript 로 만든다.
+- 이미지 변환 처리는 Next.js 서버가 아니라 Rust API 서버가 맡는다.
+- 초기 트래픽은 적을 가능성이 높으므로, Rust API 는 사용하지 않을 때 0 인스턴스까지 줄어드는 Cloud Run 배포를 우선 검토한다.
+- UI 시스템은 하나로 통일한다. MVP 기준으로는 Tailwind CSS + shadcn/ui 를 기본값으로 둔다.
+
+## 목표 아키텍처
+
+```text
+image-converter/
+├── apps/
+│   └── web/              # Next.js + TypeScript + Tailwind CSS + shadcn/ui
+├── src/
+│   ├── main.rs           # 기존 CLI 진입점 유지
+│   ├── lib.rs            # 변환 코어 공개 API
+│   └── ...
+└── src/bin/
+    └── server.rs         # Rust HTTP API 서버 후보
+```
+
+초기에는 큰 workspace 분리보다 `src/bin/server.rs` 를 추가하는 방식이 작고 안전합니다. 웹 API 의 책임이 커지면 그때 `crates/core`, `crates/cli`, `crates/api` 또는 `apps/api` 형태로 나눕니다.
+
+## Next.js 와 Cloud Run 역할 분리
+
+Next.js 는 사용자가 보는 화면과 프론트엔드 상태를 담당합니다. Cloud Run 은 Google Cloud Platform 안에서 Docker 컨테이너를 실행하는 관리형 서비스이고, 여기에는 Rust 변환 API 서버를 올립니다.
+
+```text
+사용자 브라우저
+  ├─ GET https://example.com
+  │    └─ Next.js 가 변환 화면 제공
+  │
+  └─ POST https://api.example.com/v1/convert
+       └─ Cloud Run 의 Rust API 가 이미지 변환 후 결과 반환
+```
+
+중요한 점은 이미지 파일을 Vercel/Next.js 서버 함수로 프록시하지 않는 것입니다. Vercel Functions 는 request/response payload 제한이 작아서 이미지 변환 주 경로로 쓰기 어렵습니다. 따라서 브라우저가 Rust API 로 직접 업로드하고, Next.js 는 파일을 직접 처리하지 않습니다.
+
+나중에 로그인과 결제가 들어가도 흐름은 비슷합니다.
+
+```text
+1. 사용자가 Next.js 앱에서 로그인
+2. Next.js 또는 인증 제공자가 access token 발급
+3. 브라우저가 이미지와 token 을 Rust API 로 전송
+4. Rust API 가 token/요금제/사용량 제한을 확인
+5. 변환 실행 후 결과 반환
+```
+
+초기 MVP 에서는 인증 없이 공개 변환 API 로 시작하되, 파일 크기와 동시성 제한을 반드시 둡니다.
+
+## API 서버 설계
+
+Rust API 서버는 `axum` 기반을 우선 검토합니다.
+
+초기 엔드포인트:
+
+- `GET /healthz`: 배포와 모니터링용 상태 확인
+- `POST /v1/convert`: multipart 업로드 + 변환 옵션 처리
+
+`POST /v1/convert` 입력:
+
+- 파일 1개
+- 출력 포맷: `png`, `jpg`, `jpeg`, `webp`, `avif`
+- 품질: 1-100
+- 최대 가로 크기: 선택
+- JPEG 배경색: JPG/JPEG 출력일 때만 선택
+
+처리 흐름:
+
+```text
+multipart 요청 수신
+  -> 업로드 크기 제한 확인
+  -> 임시 디렉토리에 원본 저장
+  -> 확장자/디코딩 가능 여부 확인
+  -> 기존 convert_image_silent_with_conversion_options 호출
+  -> 결과 파일 stream/download 응답
+  -> 임시 파일 삭제
+```
+
+성능과 안정성을 위해 이미지 변환은 async request task 안에서 직접 오래 붙잡지 않고 `spawn_blocking` 또는 제한된 worker pool 로 넘깁니다. AVIF/HEIC 변환은 CPU 와 메모리를 많이 쓸 수 있으므로 `Semaphore` 로 동시 변환 수를 제한합니다.
+
+## UI 시스템 결정
+
+여러 UI 라이브러리를 동시에 설치해서 섞지 않습니다. Tailwind 기반이라도 각 라이브러리의 theme token, spacing, radius, animation, focus style 이 달라지면 제품이 금방 흐트러집니다.
+
+MVP 기준 권장안:
+
+- Tailwind CSS
+- shadcn/ui
+- lucide-react
+- 필요한 경우 Framer Motion 은 직접 만든 소수 컴포넌트에만 사용
+
+shadcn/ui 를 기본 UI 시스템으로 확정합니다. 기본 문서와 예제는 흑백 톤이 강하지만, shadcn/ui 는 완성된 테마를 그대로 쓰는 라이브러리라기보다 프로젝트 안으로 가져와 소유하는 컴포넌트 출발점에 가깝습니다. 따라서 초기부터 우리 서비스의 색상, radius, spacing, 버튼 위계, 업로드 영역, 결과 비교 UI 를 별도 design token 으로 잡습니다.
+
+shadcn/ui 를 고르는 이유:
+
+- Next.js, TypeScript, Tailwind 와 궁합이 좋다.
+- 컴포넌트 소스가 프로젝트 안으로 들어와 커스터마이징하기 쉽다.
+- AI 가 수정하기 좋은 구조다.
+- Radix 기반 컴포넌트가 많아 접근성 기본기가 좋다.
+- 대시보드보다 실제 도구 화면을 만들기 쉽다.
+- Pro 컴포넌트 구매 압박 없이 무료 기반으로 제품 UI 를 쌓기 좋다.
+
+다른 UI 후보의 사용 원칙:
+
+- daisyUI: 빠른 프로토타입에는 좋지만 MVP 기본 UI 시스템으로는 shadcn/ui 를 우선한다.
+- HeroUI: 기본 스타일이 잘 잡힌 완성형 컴포넌트 라이브러리지만, 유료 Pro 영역과 라이브러리 고유 테마 의존성을 고려해 MVP 기본값으로 쓰지 않는다. shadcn/ui 와 동시에 쓰지 않는다.
+- Magic UI / Aceternity UI: 랜딩 페이지 효과 참고용으로만 본다. 꼭 필요한 경우에도 설치형 라이브러리로 섞기보다 코드를 로컬 컴포넌트로 가져와 우리 design token 에 맞춘다.
+- TailAdmin: 공개 변환 도구 화면에는 쓰지 않는다. 나중에 관리자/사용량/결제 대시보드가 필요할 때 별도 검토한다.
+
+## 초기 화면 UX
+
+첫 화면은 랜딩 페이지가 아니라 실제 변환 도구여야 합니다.
+
+핵심 화면 구성:
+
+- 드래그 앤 드롭 업로드 영역
+- 원본 정보: 파일명, 포맷, 용량, 크기
+- 출력 포맷 선택: WebP, AVIF, PNG, JPEG
+- 품질 슬라이더: PNG 선택 시 비활성 또는 무손실 표시
+- 최대 가로 크기 옵션
+- JPEG 배경색 옵션
+- 변환 버튼과 진행 상태
+- 결과: 변환 전/후 용량, 감소율, 출력 크기, 다운로드 버튼
+
+배치 변환은 2단계로 둡니다. 처음부터 ZIP 생성과 서버 job queue 를 만들면 범위가 커지므로, MVP 에서는 여러 파일을 브라우저에서 제한 병렬로 단일 변환 API 에 보내는 방식부터 검토합니다.
+
+## 배포 전략
+
+### 1안: Next.js 는 Vercel, Rust API 는 Cloud Run
+
+초기 추천안입니다.
+
+```text
+example.com           -> Vercel 의 Next.js 앱
+api.example.com       -> Google Cloud Run 의 Rust API
+```
+
+장점:
+
+- 프론트엔드 배포와 preview 환경이 편하다.
+- Rust API 는 사용하지 않을 때 0 인스턴스까지 줄일 수 있다.
+- 이미지 파일이 Vercel Function 을 지나지 않아 payload 제한을 피할 수 있다.
+
+주의점:
+
+- CORS 설정이 필요하다.
+- 인증/결제 도입 시 Rust API 가 token 을 검증할 수 있어야 한다.
+- 큰 파일 업로드가 필요해지면 Cloud Storage signed URL + 비동기 job 으로 확장한다.
+
+### 2안: Next.js 와 Rust API 모두 Cloud Run
+
+Vercel 의 플랫폼 제한을 더 피하고 싶거나, 한 클라우드 안에서 끝내고 싶을 때 선택합니다. Next.js 는 `output: "standalone"` Docker 빌드로 Cloud Run 에 올릴 수 있습니다.
+
+장점:
+
+- Google Cloud 안에서 서비스 구성이 단순해진다.
+- 도메인, 인증, 로깅, secret 관리 정책을 한쪽으로 모을 수 있다.
+
+주의점:
+
+- Next.js preview/deploy 경험은 Vercel 보다 손이 더 간다.
+- 프론트엔드도 Cloud Run cold start 영향을 받을 수 있다.
+
+### 3안: Render
+
+Docker 배포 경험이 쉽고 월 고정비 예측이 편합니다. 빠르게 공개 MVP 를 띄우는 데 좋지만, 트래픽이 거의 없을 때도 유료 인스턴스 비용이 생길 수 있습니다.
+
+### 4안: AWS
+
+AWS 를 쓴다면 App Runner 가 Cloud Run 과 가장 비슷한 선택지입니다. 더 세밀한 운영과 확장이 필요하면 ECS Fargate 로 갈 수 있습니다. Lightsail/EC2 는 비용을 낮출 수 있지만 서버 운영 책임이 커집니다.
+
+## 비용 관점
+
+초기에는 사용량이 적을 가능성이 높기 때문에, 요청이 없을 때 비용이 거의 사라지는 Cloud Run request-based billing 이 잘 맞습니다. 월 고정비를 내더라도 항상 빠른 응답과 단순한 운영을 원하면 Render 나 Lightsail 같은 선택지가 더 편할 수 있습니다.
+
+대략적인 판단:
+
+- 낮은 사용량, 불확실한 트래픽: Cloud Run
+- 월 고정비 예측과 쉬운 배포: Render
+- AWS 생태계 진입: App Runner
+- 직접 운영 가능하고 최저 비용 지향: Lightsail/EC2/VPS
+
+## 수익화 확장
+
+처음부터 결제를 붙이지는 않습니다. 대신 나중에 결제를 붙이기 쉬운 경계만 잡아둡니다.
+
+향후 기능:
+
+- 로그인
+- 사용자별 일일 변환 횟수 제한
+- 무료/유료 파일 크기 제한
+- 큰 파일 또는 배치 변환 유료화
+- 변환 기록 저장
+- API key 발급
+- Stripe 결제
+
+데이터 저장 후보:
+
+- 초기: 변환 결과는 저장하지 않고 즉시 삭제
+- 로그인 이후: 사용자, 사용량, 결제 상태만 DB 에 저장
+- 큰 파일 이후: Cloud Storage 같은 object storage 에 원본/결과를 짧은 TTL 로 저장
+
+## 안정화 체크리스트
+
+- 업로드 파일 크기 제한
+- 디코딩 후 최대 픽셀 수 제한
+- 변환 동시성 제한
+- AVIF 변환 timeout 설정
+- 임시 파일 자동 삭제
+- 결과 파일 stream 응답
+- CORS 허용 origin 제한
+- 요청별 trace id 로 로그 추적
+- 변환 시간, 입력/출력 크기, 실패 원인 기록
+- 실제 이미지 코퍼스 기반 부하 테스트
+
+## 단계별 실행 계획
+
+1. Rust API 서버 추가
+   - `GET /healthz`
+   - `POST /v1/convert`
+   - 기존 변환 코어 재사용
+   - 파일 크기/픽셀 수/동시성 제한
+
+2. Next.js 웹 앱 추가
+   - Tailwind CSS + shadcn/ui
+   - 단일 이미지 변환 화면
+   - 변환 결과 다운로드
+
+3. 로컬 개발 환경 확장
+   - Docker Compose 에 `web`, `api` 서비스 추가
+   - 기존 `./scripts/check.sh` 와 별도 웹 검사 스크립트 구성
+
+4. E2E 검증
+   - Playwright 로 업로드, 변환, 다운로드 확인
+   - WebP/AVIF/PNG/JPEG 주요 경로 테스트
+
+5. MVP 배포
+   - Rust API: Cloud Run
+   - Next.js: Vercel 또는 Cloud Run
+   - 도메인, CORS, 업로드 제한 설정
+
+6. 수익화 준비
+   - 로그인
+   - 사용량 기록
+   - 요금제 제한
+   - Stripe 결제
+
+## 참고 문서
+
+- Cloud Run 개요: https://docs.cloud.google.com/run/docs/overview/what-is-cloud-run
+- Cloud Run 가격: https://cloud.google.com/run/pricing
+- Next.js self-hosting: https://nextjs.org/docs/app/guides/self-hosting
+- Next.js standalone output: https://nextjs.org/docs/app/api-reference/config/next-config-js/output
+- Vercel Functions limits: https://vercel.com/docs/functions/limitations
+- AWS App Runner 가격: https://aws.amazon.com/apprunner/pricing/
+- AWS Fargate 가격: https://aws.amazon.com/fargate/pricing/
+- Amazon Lightsail 가격: https://aws.amazon.com/lightsail/pricing/


### PR DESCRIPTION
- Next.js 웹 앱과 Rust 변환 API의 역할 분리를 문서화

- Cloud Run 중심의 초기 배포 전략과 비용 판단을 정리

- shadcn/ui 단일 UI 시스템과 수익화 확장 방향을 명시