### PR TITLE
feat: 로컬 Rust API 서버 추가

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +201,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "multer",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -480,6 +539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enumn"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,10 +650,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "four-cc"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795cbfc56d419a7ce47ccbb7504dd9a5b7c484c083c356e797de08bd988d9629"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -596,7 +706,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -647,6 +757,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +876,7 @@ dependencies = [
 name = "image_converter"
 version = "2.6.0"
 dependencies = [
+ "axum",
  "clap",
  "colored",
  "dialoguer",
@@ -695,8 +886,12 @@ dependencies = [
  "ravif",
  "rayon",
  "rexpect",
+ "serde",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
+ "tower",
+ "tower-http",
  "walkdir",
  "webp",
 ]
@@ -755,6 +950,12 @@ checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -863,6 +1064,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +1086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +1105,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -916,6 +1140,23 @@ dependencies = [
  "log",
  "num-traits",
  "static_assertions",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1040,6 +1281,18 @@ name = "pastey"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a8cb46bdc156b1c90460339ae6bfd45ba0394e5effbaa640badb4987fdc261"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -1308,12 +1561,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1337,12 +1606,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1373,10 +1678,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1406,6 +1733,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "system-deps"
@@ -1494,6 +1827,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1889,68 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1588,6 +2008,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1825,6 +2251,12 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ image = { version = "0.25.10", features = ["avif-native"] }
 webp = "0.3.1"
 ravif = "0.13.0"
 libheif-rs = { version = "2.7.0", default-features = false, features = ["v1_17", "image"] }
+axum = { version = "0.8", features = ["multipart"] }
 clap = { version = "4.5", features = ["derive"] }
 dialoguer = "0.11"
 colored = "2.1"
@@ -23,10 +24,14 @@ indicatif = "0.17"
 walkdir = "2.5"
 thiserror = "1.0"
 rayon = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+tempfile = "3.0"
+tokio = { version = "1.48", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tower-http = { version = "0.6", features = ["cors"] }
 
 [dev-dependencies]
-tempfile = "3.0"
 colored = "2.1"
+tower = { version = "0.5", features = ["util"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 rexpect = "0.7.0"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ docker compose run --rm dev cargo run --release
 # 자동화용 명령줄 모드 실행
 docker compose run --rm dev cargo run --release -- -i input.png -o output.webp -f webp
 
+# 로컬 API 서버 실행
+docker compose up api
+
+# API 상태 확인
+curl http://localhost:4000/healthz
+
+# 단일 이미지 변환 API 호출
+curl -X POST http://localhost:4000/v1/convert \
+  -F file=@input.png \
+  -F format=webp \
+  -F quality=90 \
+  --output output.webp
+
 # 컨테이너 안에서 셸 열기
 docker compose run --rm dev
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,29 @@ services:
     stdin_open: true
     tty: true
 
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        RUST_IMAGE: ${RUST_IMAGE:-rust:1-trixie}
+    image: image-converter-dev
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+      - cargo-registry:/usr/local/cargo/registry
+      - cargo-git:/usr/local/cargo/git
+      - target:/workspace/target
+    environment:
+      CARGO_TARGET_DIR: /workspace/target
+      RUST_BACKTRACE: "1"
+      HOST: 0.0.0.0
+      PORT: 4000
+      CONVERT_ALLOWED_ORIGIN: ${CONVERT_ALLOWED_ORIGIN:-http://localhost:3000}
+    ports:
+      - "${API_PORT:-4000}:4000"
+    command: cargo run --bin server
+
 volumes:
   cargo-registry:
   cargo-git:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ image_converter/
 ├── .dockerignore           # Docker 빌드 컨텍스트 제외 파일
 ├── AGENTS.md               # 에이전트 공통 작업 규칙
 ├── Dockerfile              # Rust + nasm + dav1d + libheif 개발 컨테이너 이미지
-├── docker-compose.yml      # 개발/테스트용 컨테이너 실행 설정
+├── docker-compose.yml      # 개발/테스트용 컨테이너와 로컬 API 서버 실행 설정
 ├── Cargo.toml              # Rust 프로젝트 설정 및 의존성
 ├── README.md               # 프로젝트 사용 가이드
 ├── scripts/
@@ -25,6 +25,8 @@ image_converter/
 └── src/
     ├── main.rs             # 진입점 - CLI 인자 처리, 단일/일괄 분기
     ├── lib.rs              # 라이브러리 루트 - 공개 API re-export
+    ├── bin/
+    │   └── server.rs       # 로컬/웹 확장용 HTTP API 서버 진입점
     ├── error.rs            # ConverterError + Result 타입 (thiserror 기반)
     ├── format.rs           # OutputFormat enum + 출력 포맷 파싱/표시 헬퍼
     ├── input.rs            # image 크레이트 추가 입력 디코더 등록
@@ -50,6 +52,22 @@ image_converter/
 - 자동화용 옵션으로 최대 가로 크기(`--max-width`) 와 JPEG 배경색(`--jpeg-background`) 을 받아 `ConversionOptions` 로 전달
 - 비대화형 일괄 변환은 모든 대상 처리를 끝낸 뒤 실패 파일이 1개 이상이면 `BatchPartialFailure` 로 종료해 자동화에서 non-zero 상태를 받을 수 있게 함 (`skipped` 는 실패로 보지 않음)
 - 에러 처리 및 종료 — `ConverterError` 의 `Display` 로 메시지 출력
+
+### `src/bin/server.rs` (HTTP API 서버)
+
+- 웹 서비스 확장을 위한 `axum` 기반 API 서버 진입점
+- `GET /healthz` 로 로컬 실행과 배포 헬스체크에 사용할 상태 응답 제공
+- `POST /v1/convert` 에서 multipart 업로드를 받아 단일 이미지를 변환
+  - `file`: 업로드 이미지 파일 1개
+  - `format`: `png` / `jpg` / `jpeg` / `webp` / `avif`
+  - `quality`: 선택, 기본 90, 1-100 범위
+  - `max_width`: 선택, 1 이상의 픽셀 값
+  - `jpeg_background`: 선택, JPG/JPEG 출력에서만 `white` / `black` / `#RRGGBB`
+- 변환 자체는 `convert_image_silent_with_conversion_options` 를 호출해 기존 라이브러리 코어를 재사용
+- 업로드 크기, 디코딩 전 이미지 픽셀 수, 동시 변환 수, 변환 timeout 을 제한
+- CPU 중심 변환은 async runtime 을 오래 점유하지 않도록 `tokio::task::spawn_blocking` 에서 실행
+- 로컬 CORS 허용 origin 은 기본 `http://localhost:3000` 이며 `CONVERT_ALLOWED_ORIGIN` 으로 바꿀 수 있음
+- Docker Compose 의 `api` 서비스로 `http://localhost:4000` 에서 실행 가능
 
 ### `error.rs` (에러 타입)
 
@@ -142,6 +160,8 @@ image_converter/
 
 - `Dockerfile`: 공식 Rust Debian 이미지를 기반으로 `nasm`, `libdav1d-dev`, `libheif-dev`, `libheif-plugin-x265`, `pkg-config`, `rustfmt`, `clippy` 를 설치
 - `docker-compose.yml`: 현재 작업 디렉토리를 `/workspace` 로 마운트하고 Cargo registry/git/target 을 Docker named volume 으로 분리
+  - `dev`: 기존 개발/테스트용 컨테이너
+  - `api`: `cargo run --bin server` 로 로컬 API 서버를 실행하고 `${API_PORT:-4000}:4000` 을 노출
 - `scripts/check.sh`: Docker 컨테이너에서 `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` 를 한 번에 실행. `--local` 옵션을 주면 호스트 Cargo 로 실행
 - 기본 이미지는 `rust:1-trixie` (`dav1d >= 1.3.0` 필요), 필요 시 `RUST_IMAGE=rust:1.94-trixie docker compose build` 처럼 고정 가능
 - Docker 의 `target` 은 named volume 이므로 Docker release 빌드는 컨테이너 실행/검증용 Linux 바이너리로 다루고, 호스트 설치용 바이너리는 로컬 Cargo 빌드/설치 경로로 분리
@@ -172,6 +192,12 @@ main.rs
         │     ├── batch.rs
         │     └── format.rs
         └── tests/ (테스트에서만 사용)
+
+server.rs
+  └── image_converter (lib)
+        ├── converter.rs (단일 변환 코어)
+        ├── format.rs (출력 포맷 타입)
+        └── input.rs (추가 입력 디코더 등록)
 ```
 
 ## 향후 개선 제안

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,6 +12,26 @@
 
 ## 최근 작업 로그
 
+### 2026-05-04 — 로컬 Rust API 서버 1차 추가
+
+- 웹 서비스 확장 첫 구현 단위로 `src/bin/server.rs` 추가
+  - `GET /healthz`
+  - `POST /v1/convert` multipart 단일 이미지 변환
+  - 기존 `convert_image_silent_with_conversion_options` 로 변환 코어 재사용
+- API 서버 안정화 기본값 추가
+  - 업로드 크기 제한: `CONVERT_MAX_UPLOAD_BYTES` (기본 25MiB)
+  - 디코딩 전 픽셀 수 제한: `CONVERT_MAX_PIXELS` (기본 80,000,000)
+  - 동시 변환 제한: `CONVERT_MAX_CONCURRENCY` (기본 2)
+  - 변환 timeout: `CONVERT_TIMEOUT_SECONDS` (기본 120초)
+  - CORS 허용 origin: `CONVERT_ALLOWED_ORIGIN` (기본 `http://localhost:3000`)
+- `docker compose up api` 로 `http://localhost:4000` 에서 로컬 API 서버를 실행할 수 있게 `api` 서비스 추가
+- HTTP API 서버 테스트 4개 추가
+  - `healthz_returns_ok`
+  - `convert_png_to_webp_returns_download`
+  - `convert_rejects_missing_file`
+  - `convert_rejects_too_many_pixels`
+- README / docs/architecture.md / docs/testing.md 갱신
+
 ### 2026-05-04 — 프로젝트 전용 에이전트 스킬 추가
 
 - `npx skills` 로 Codex/Claude Code 양쪽에 프로젝트 범위 skill 설치

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,6 +9,8 @@
 ```
 src/
   main.rs         # CLI 인자 파서 단위 테스트 (#[cfg(test)] mod tests)
+  bin/
+    server.rs     # HTTP API 서버 라우터/변환 요청 단위 테스트
   interactive.rs  # 대화형 모드 검증/경로/옵션 단위 테스트 (#[cfg(test)] mod tests)
   lib.rs          # 테스트용 함수들
   tests/
@@ -42,6 +44,12 @@ docker compose run --rm dev cargo test
 
 ```bash
 docker compose run --rm dev cargo test -- --nocapture
+```
+
+API 서버 테스트만 빠르게 확인하려면 다음처럼 실행합니다.
+
+```bash
+docker compose run --rm dev cargo test --bin server
 ```
 
 릴리즈 모드 테스트도 컨테이너 안에서 실행할 수 있습니다.
@@ -365,6 +373,22 @@ cargo test --release
 
 55. **`non_interactive_batch_skipped_outputs_still_succeed`**
     - 기존 출력 파일 때문에 건너뛴 항목만 있는 배치 변환은 성공 종료하고 기존 파일을 보존하는지 확인
+
+### 🌐 HTTP API 서버 테스트 (`src/bin/server.rs`)
+
+56. **`healthz_returns_ok`**
+    - `GET /healthz` 가 200 OK 와 `ok` 본문을 반환하는지 확인
+
+57. **`convert_png_to_webp_returns_download`**
+    - multipart 요청으로 PNG 파일과 변환 옵션을 보내면 WebP 다운로드 응답을 반환하는지 확인
+    - `max_width` 적용 결과가 응답 헤더(`x-output-width`)에 반영되는지 검증
+    - 출력 본문이 WebP 시그니처(`RIFF` / `WEBP`) 로 시작하는지 확인
+
+58. **`convert_rejects_missing_file`**
+    - `file` 필드가 없는 multipart 요청은 400 Bad Request 로 거부하는지 확인
+
+59. **`convert_rejects_too_many_pixels`**
+    - 디코딩 전 픽셀 수 제한을 넘는 이미지는 413 Payload Too Large 로 거부하는지 확인
 
 ## 테스트 매크로
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,0 +1,782 @@
+use axum::{
+    body::Body,
+    extract::{DefaultBodyLimit, Multipart, State},
+    http::{
+        header::{CONTENT_DISPOSITION, CONTENT_TYPE},
+        HeaderName, HeaderValue, Method, StatusCode,
+    },
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use image_converter::{
+    convert_image_silent_with_conversion_options, input::register_extra_decoders,
+    ConversionOptions, ConvertStats, JpegBackground, OutputFormat, ResizeOptions,
+};
+use serde::Serialize;
+use std::{env, fs, net::SocketAddr, path::Path, str::FromStr, sync::Arc, time::Duration};
+use tokio::{
+    net::TcpListener,
+    sync::{OwnedSemaphorePermit, Semaphore},
+    task, time,
+};
+use tower_http::cors::CorsLayer;
+
+const DEFAULT_HOST: &str = "0.0.0.0";
+const DEFAULT_PORT: u16 = 4000;
+const DEFAULT_ALLOWED_ORIGIN: &str = "http://localhost:3000";
+const DEFAULT_MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
+const DEFAULT_MAX_PIXELS: u64 = 80_000_000;
+const DEFAULT_MAX_CONCURRENCY: usize = 2;
+const DEFAULT_TIMEOUT_SECONDS: u64 = 120;
+const MULTIPART_OVERHEAD_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy, Debug)]
+struct ServerConfig {
+    max_upload_bytes: usize,
+    max_pixels: u64,
+    max_concurrency: usize,
+    conversion_timeout: Duration,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            max_upload_bytes: DEFAULT_MAX_UPLOAD_BYTES,
+            max_pixels: DEFAULT_MAX_PIXELS,
+            max_concurrency: DEFAULT_MAX_CONCURRENCY,
+            conversion_timeout: Duration::from_secs(DEFAULT_TIMEOUT_SECONDS),
+        }
+    }
+}
+
+impl ServerConfig {
+    fn from_env() -> Result<Self, Box<dyn std::error::Error>> {
+        let timeout_seconds = parse_env_u64("CONVERT_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS)?;
+        Ok(Self {
+            max_upload_bytes: parse_env_usize(
+                "CONVERT_MAX_UPLOAD_BYTES",
+                DEFAULT_MAX_UPLOAD_BYTES,
+            )?,
+            max_pixels: parse_env_u64("CONVERT_MAX_PIXELS", DEFAULT_MAX_PIXELS)?,
+            max_concurrency: parse_env_usize("CONVERT_MAX_CONCURRENCY", DEFAULT_MAX_CONCURRENCY)?
+                .max(1),
+            conversion_timeout: Duration::from_secs(timeout_seconds.max(1)),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct AppState {
+    conversions: Arc<Semaphore>,
+    config: ServerConfig,
+}
+
+#[derive(Debug)]
+struct UploadedImage {
+    file_name: String,
+    extension: String,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct ConvertRequest {
+    image: UploadedImage,
+    format: OutputFormat,
+    quality: f32,
+    options: ConversionOptions,
+}
+
+struct ConvertedImage {
+    bytes: Vec<u8>,
+    stats: ConvertStats,
+    format: OutputFormat,
+    file_name: String,
+}
+
+#[derive(Debug)]
+struct ApiError {
+    status: StatusCode,
+    code: &'static str,
+    message: String,
+}
+
+#[derive(Serialize)]
+struct ErrorResponse<'a> {
+    error: ErrorDetail<'a>,
+}
+
+#[derive(Serialize)]
+struct ErrorDetail<'a> {
+    code: &'a str,
+    message: &'a str,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = ServerConfig::from_env()?;
+    let host = env::var("HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string());
+    let port = parse_env_u16("PORT", DEFAULT_PORT)?;
+    let addr: SocketAddr = format!("{host}:{port}").parse()?;
+    let allowed_origin = allowed_origin_from_env()?;
+    let app = build_router(config, allowed_origin);
+
+    println!("이미지 변환 API 서버 실행 중: http://{addr}");
+    println!(
+        "업로드 제한: {} bytes, 픽셀 제한: {}, 동시 변환: {}",
+        config.max_upload_bytes, config.max_pixels, config.max_concurrency
+    );
+
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+fn build_router(config: ServerConfig, allowed_origin: HeaderValue) -> Router {
+    let exposed_headers = [
+        CONTENT_DISPOSITION,
+        header_name("x-input-size"),
+        header_name("x-output-size"),
+        header_name("x-input-width"),
+        header_name("x-input-height"),
+        header_name("x-output-width"),
+        header_name("x-output-height"),
+    ];
+    let cors = CorsLayer::new()
+        .allow_origin(allowed_origin)
+        .allow_methods([Method::GET, Method::POST])
+        .allow_headers([CONTENT_TYPE])
+        .expose_headers(exposed_headers);
+
+    let state = AppState {
+        conversions: Arc::new(Semaphore::new(config.max_concurrency)),
+        config,
+    };
+
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route(
+            "/v1/convert",
+            post(convert).layer(DefaultBodyLimit::max(
+                config.max_upload_bytes + MULTIPART_OVERHEAD_BYTES,
+            )),
+        )
+        .layer(cors)
+        .with_state(state)
+}
+
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+async fn convert(
+    State(state): State<AppState>,
+    multipart: Multipart,
+) -> Result<Response, ApiError> {
+    let request = parse_multipart(multipart, state.config.max_upload_bytes).await?;
+    let converted = run_conversion(state, request).await?;
+    Ok(converted.into_response())
+}
+
+async fn parse_multipart(
+    mut multipart: Multipart,
+    max_upload_bytes: usize,
+) -> Result<ConvertRequest, ApiError> {
+    let mut image = None;
+    let mut format = None;
+    let mut quality = None;
+    let mut max_width = None;
+    let mut jpeg_background = None;
+
+    while let Some(field) = multipart.next_field().await? {
+        let name = field.name().map(str::to_owned);
+        let file_name = field.file_name().map(str::to_owned);
+        let bytes = field.bytes().await?;
+        let Some(name) = name else {
+            continue;
+        };
+
+        match name.as_str() {
+            "file" => {
+                if image.is_some() {
+                    return Err(ApiError::bad_request(
+                        "duplicate_file",
+                        "이미지 파일은 하나만 업로드할 수 있습니다",
+                    ));
+                }
+                if bytes.is_empty() {
+                    return Err(ApiError::bad_request(
+                        "empty_file",
+                        "업로드 파일이 비어 있습니다",
+                    ));
+                }
+                if bytes.len() > max_upload_bytes {
+                    return Err(ApiError::payload_too_large(format!(
+                        "업로드 파일은 최대 {max_upload_bytes} bytes 까지만 허용됩니다"
+                    )));
+                }
+
+                let file_name = file_name.ok_or_else(|| {
+                    ApiError::bad_request(
+                        "missing_file_name",
+                        "업로드 파일 이름을 확인할 수 없습니다",
+                    )
+                })?;
+                let extension = input_extension(&file_name)?;
+                image = Some(UploadedImage {
+                    file_name,
+                    extension,
+                    bytes: bytes.to_vec(),
+                });
+            }
+            "format" => {
+                format = Some(parse_output_format(text_field("format", bytes)?)?);
+            }
+            "quality" => {
+                quality = Some(parse_quality(&text_field("quality", bytes)?)?);
+            }
+            "max_width" => {
+                let value = text_field("max_width", bytes)?;
+                if !value.trim().is_empty() {
+                    max_width = Some(parse_max_width(&value)?);
+                }
+            }
+            "jpeg_background" => {
+                let value = text_field("jpeg_background", bytes)?;
+                if !value.trim().is_empty() {
+                    jpeg_background = Some(parse_jpeg_background(&value)?);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let image =
+        image.ok_or_else(|| ApiError::bad_request("missing_file", "file 필드가 필요합니다"))?;
+    let format = format
+        .ok_or_else(|| ApiError::bad_request("missing_format", "format 필드가 필요합니다"))?;
+
+    if jpeg_background.is_some() && !format.is_jpeg() {
+        return Err(ApiError::bad_request(
+            "invalid_jpeg_background",
+            "jpeg_background 은 JPG/JPEG 출력에서만 사용할 수 있습니다",
+        ));
+    }
+
+    Ok(ConvertRequest {
+        image,
+        format,
+        quality: quality.unwrap_or(90.0),
+        options: ConversionOptions {
+            resize: max_width.map(|max_width| ResizeOptions { max_width }),
+            jpeg_background,
+        },
+    })
+}
+
+async fn run_conversion(
+    state: AppState,
+    request: ConvertRequest,
+) -> Result<ConvertedImage, ApiError> {
+    let permit = state
+        .conversions
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| ApiError::internal("변환 동시성 제한기를 사용할 수 없습니다"))?;
+    let timeout = state.config.conversion_timeout;
+    let max_pixels = state.config.max_pixels;
+    let task = task::spawn_blocking(move || convert_in_tempdir(request, permit, max_pixels));
+
+    match time::timeout(timeout, task).await {
+        Ok(joined) => joined.map_err(|error| {
+            ApiError::internal(format!("변환 작업을 완료하지 못했습니다: {error}"))
+        })?,
+        Err(_) => Err(ApiError::timeout(format!(
+            "이미지 변환이 {}초 안에 끝나지 않았습니다",
+            timeout.as_secs()
+        ))),
+    }
+}
+
+fn convert_in_tempdir(
+    request: ConvertRequest,
+    permit: OwnedSemaphorePermit,
+    max_pixels: u64,
+) -> Result<ConvertedImage, ApiError> {
+    let _permit = permit;
+    let temp_dir = tempfile::tempdir()?;
+    let input_path = temp_dir
+        .path()
+        .join(format!("input.{}", request.image.extension));
+    let output_path = temp_dir
+        .path()
+        .join(format!("output.{}", output_extension(request.format)));
+
+    fs::write(&input_path, request.image.bytes)?;
+    ensure_pixel_limit(&input_path, max_pixels)?;
+
+    let input_path = path_to_string(&input_path)?;
+    let output_path = path_to_string(&output_path)?;
+    let stats = convert_image_silent_with_conversion_options(
+        &input_path,
+        &output_path,
+        request.format,
+        request.quality,
+        request.options,
+    )
+    .map_err(ApiError::conversion)?;
+    let bytes = fs::read(&output_path)?;
+
+    Ok(ConvertedImage {
+        bytes,
+        stats,
+        format: request.format,
+        file_name: download_file_name(&request.image.file_name, request.format),
+    })
+}
+
+fn ensure_pixel_limit(path: &Path, max_pixels: u64) -> Result<(), ApiError> {
+    register_extra_decoders();
+    let (width, height) = image::image_dimensions(path).map_err(ApiError::image)?;
+    let pixels = u64::from(width) * u64::from(height);
+    if pixels > max_pixels {
+        return Err(ApiError::payload_too_large(format!(
+            "이미지가 너무 큽니다: {width}x{height} px ({pixels} pixels, 제한: {max_pixels})"
+        )));
+    }
+    Ok(())
+}
+
+impl ConvertedImage {
+    fn into_response(self) -> Response {
+        let mut response = Response::new(Body::from(self.bytes));
+        let headers = response.headers_mut();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static(content_type(self.format)),
+        );
+        headers.insert(
+            CONTENT_DISPOSITION,
+            HeaderValue::from_str(&format!("attachment; filename=\"{}\"", self.file_name))
+                .expect("download file name은 ASCII 안전 문자열이어야 함"),
+        );
+        insert_number_header(headers, "x-input-size", self.stats.input_size);
+        insert_number_header(headers, "x-output-size", self.stats.output_size);
+        insert_number_header(headers, "x-input-width", self.stats.width);
+        insert_number_header(headers, "x-input-height", self.stats.height);
+        insert_number_header(headers, "x-output-width", self.stats.output_width);
+        insert_number_header(headers, "x-output-height", self.stats.output_height);
+        response
+    }
+}
+
+impl ApiError {
+    fn bad_request(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code,
+            message: message.into(),
+        }
+    }
+
+    fn payload_too_large(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+            code: "payload_too_large",
+            message: message.into(),
+        }
+    }
+
+    fn timeout(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::REQUEST_TIMEOUT,
+            code: "conversion_timeout",
+            message: message.into(),
+        }
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "internal_error",
+            message: message.into(),
+        }
+    }
+
+    fn image(error: image::ImageError) -> Self {
+        Self::bad_request(
+            "invalid_image",
+            format!("이미지를 읽을 수 없습니다: {error}"),
+        )
+    }
+
+    fn conversion(error: image_converter::ConverterError) -> Self {
+        match error {
+            image_converter::ConverterError::Image(error) => Self::image(error),
+            image_converter::ConverterError::UnsupportedFormat(format) => Self::bad_request(
+                "unsupported_format",
+                format!("지원하지 않는 포맷입니다: {format}"),
+            ),
+            other => Self::internal(format!("이미지 변환에 실패했습니다: {other}")),
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = ErrorResponse {
+            error: ErrorDetail {
+                code: self.code,
+                message: &self.message,
+            },
+        };
+        (self.status, Json(body)).into_response()
+    }
+}
+
+impl From<std::io::Error> for ApiError {
+    fn from(error: std::io::Error) -> Self {
+        Self::internal(format!("입출력 오류: {error}"))
+    }
+}
+
+impl From<axum::extract::multipart::MultipartError> for ApiError {
+    fn from(error: axum::extract::multipart::MultipartError) -> Self {
+        Self::bad_request("invalid_multipart", format!("multipart 요청 오류: {error}"))
+    }
+}
+
+fn text_field(name: &'static str, bytes: axum::body::Bytes) -> Result<String, ApiError> {
+    String::from_utf8(bytes.to_vec()).map_err(|_| {
+        ApiError::bad_request(
+            "invalid_text_field",
+            format!("{name} 필드는 UTF-8 문자열이어야 합니다"),
+        )
+    })
+}
+
+fn parse_output_format(value: String) -> Result<OutputFormat, ApiError> {
+    OutputFormat::from_str(value.trim()).map_err(|_| {
+        ApiError::bad_request(
+            "unsupported_output_format",
+            format!("지원하지 않는 출력 포맷입니다: {}", value.trim()),
+        )
+    })
+}
+
+fn parse_quality(value: &str) -> Result<f32, ApiError> {
+    let quality = value.trim().parse::<f32>().map_err(|_| {
+        ApiError::bad_request(
+            "invalid_quality",
+            format!("quality 는 1-100 숫자여야 합니다: {}", value.trim()),
+        )
+    })?;
+    if !(1.0..=100.0).contains(&quality) {
+        return Err(ApiError::bad_request(
+            "invalid_quality",
+            format!("quality 는 1-100 범위여야 합니다: {quality}"),
+        ));
+    }
+    Ok(quality)
+}
+
+fn parse_max_width(value: &str) -> Result<u32, ApiError> {
+    let max_width = value.trim().parse::<u32>().map_err(|_| {
+        ApiError::bad_request(
+            "invalid_max_width",
+            format!(
+                "max_width 는 1 이상의 픽셀 값이어야 합니다: {}",
+                value.trim()
+            ),
+        )
+    })?;
+    if max_width == 0 {
+        return Err(ApiError::bad_request(
+            "invalid_max_width",
+            "max_width 는 1 이상이어야 합니다",
+        ));
+    }
+    Ok(max_width)
+}
+
+fn parse_jpeg_background(value: &str) -> Result<JpegBackground, ApiError> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "white" => Ok(JpegBackground::white()),
+        "black" => Ok(JpegBackground::black()),
+        _ => JpegBackground::from_hex(value)
+            .map_err(|message| ApiError::bad_request("invalid_jpeg_background", message)),
+    }
+}
+
+fn input_extension(file_name: &str) -> Result<String, ApiError> {
+    let extension = Path::new(file_name)
+        .extension()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            ApiError::bad_request(
+                "missing_input_extension",
+                "업로드 파일 확장자를 확인할 수 없습니다",
+            )
+        })?
+        .to_ascii_lowercase();
+
+    if is_supported_input_extension(&extension) {
+        Ok(extension)
+    } else {
+        Err(ApiError::bad_request(
+            "unsupported_input_extension",
+            format!("지원하지 않는 입력 확장자입니다: .{extension}"),
+        ))
+    }
+}
+
+fn is_supported_input_extension(extension: &str) -> bool {
+    matches!(
+        extension,
+        "png" | "jpg" | "jpeg" | "webp" | "avif" | "heic" | "heif" | "tiff" | "tif" | "bmp" | "ico"
+    )
+}
+
+fn output_extension(format: OutputFormat) -> &'static str {
+    match format {
+        OutputFormat::Jpg | OutputFormat::Jpeg => "jpg",
+        _ => format.as_str(),
+    }
+}
+
+fn content_type(format: OutputFormat) -> &'static str {
+    match format {
+        OutputFormat::Png => "image/png",
+        OutputFormat::Jpg | OutputFormat::Jpeg => "image/jpeg",
+        OutputFormat::Webp => "image/webp",
+        OutputFormat::Avif => "image/avif",
+    }
+}
+
+fn download_file_name(input_file_name: &str, format: OutputFormat) -> String {
+    let stem = Path::new(input_file_name)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .map(sanitize_file_stem)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "converted".to_string());
+    format!("{stem}.{}", output_extension(format))
+}
+
+fn sanitize_file_stem(value: &str) -> String {
+    value
+        .chars()
+        .filter_map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                Some(ch)
+            } else if ch.is_whitespace() {
+                Some('_')
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn path_to_string(path: &Path) -> Result<String, ApiError> {
+    path.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| ApiError::internal("임시 파일 경로를 UTF-8로 변환할 수 없습니다"))
+}
+
+fn insert_number_header(
+    headers: &mut axum::http::HeaderMap,
+    name: &'static str,
+    value: impl ToString,
+) {
+    headers.insert(
+        header_name(name),
+        HeaderValue::from_str(&value.to_string()).expect("숫자 헤더 값은 유효해야 함"),
+    );
+}
+
+fn header_name(name: &'static str) -> HeaderName {
+    HeaderName::from_static(name)
+}
+
+fn allowed_origin_from_env() -> Result<HeaderValue, Box<dyn std::error::Error>> {
+    let value =
+        env::var("CONVERT_ALLOWED_ORIGIN").unwrap_or_else(|_| DEFAULT_ALLOWED_ORIGIN.to_string());
+    Ok(HeaderValue::from_str(&value)?)
+}
+
+fn parse_env_u16(name: &str, default: u16) -> Result<u16, Box<dyn std::error::Error>> {
+    match env::var(name) {
+        Ok(value) => Ok(value.parse()?),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(Box::new(error)),
+    }
+}
+
+fn parse_env_usize(name: &str, default: usize) -> Result<usize, Box<dyn std::error::Error>> {
+    match env::var(name) {
+        Ok(value) => Ok(value.parse()?),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(Box::new(error)),
+    }
+}
+
+fn parse_env_u64(name: &str, default: u64) -> Result<u64, Box<dyn std::error::Error>> {
+    match env::var(name) {
+        Ok(value) => Ok(value.parse()?),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(Box::new(error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+    };
+    use image::{ImageBuffer, ImageFormat, Rgb};
+    use std::io::Cursor;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn healthz_returns_ok() {
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], b"ok");
+    }
+
+    #[tokio::test]
+    async fn convert_png_to_webp_returns_download() {
+        let (content_type, body) =
+            multipart_body(&[("format", "webp"), ("quality", "80"), ("max_width", "16")]);
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/convert")
+                    .header(CONTENT_TYPE, content_type)
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[CONTENT_TYPE], "image/webp");
+        assert_eq!(response.headers()[header_name("x-output-width")], "16");
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(body.starts_with(b"RIFF"));
+        assert_eq!(&body[8..12], b"WEBP");
+    }
+
+    #[tokio::test]
+    async fn convert_rejects_missing_file() {
+        let boundary = "missing-file-boundary";
+        let body = text_multipart_body(boundary, &[("format", "webp")]);
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/convert")
+                    .header(
+                        CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn convert_rejects_too_many_pixels() {
+        let config = ServerConfig {
+            max_pixels: 10,
+            ..ServerConfig::default()
+        };
+        let (content_type, body) = multipart_body(&[("format", "webp")]);
+        let response = build_router(config, HeaderValue::from_static(DEFAULT_ALLOWED_ORIGIN))
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/convert")
+                    .header(CONTENT_TYPE, content_type)
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    fn test_app() -> Router {
+        build_router(
+            ServerConfig {
+                max_upload_bytes: 1024 * 1024,
+                max_pixels: 10_000,
+                max_concurrency: 1,
+                conversion_timeout: Duration::from_secs(30),
+            },
+            HeaderValue::from_static(DEFAULT_ALLOWED_ORIGIN),
+        )
+    }
+
+    fn multipart_body(fields: &[(&str, &str)]) -> (String, Vec<u8>) {
+        let boundary = "image-converter-test-boundary";
+        let mut body = text_multipart_body(boundary, fields);
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"sample.png\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
+        body.extend_from_slice(&png_bytes());
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        (format!("multipart/form-data; boundary={boundary}"), body)
+    }
+
+    fn text_multipart_body(boundary: &str, fields: &[(&str, &str)]) -> Vec<u8> {
+        let mut body = Vec::new();
+        for (name, value) in fields {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(
+                format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+            );
+            body.extend_from_slice(value.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+        body
+    }
+
+    fn png_bytes() -> Vec<u8> {
+        let image = ImageBuffer::from_fn(32, 24, |x, y| {
+            if (x + y) % 2 == 0 {
+                Rgb([255u8, 255u8, 255u8])
+            } else {
+                Rgb([0u8, 0u8, 0u8])
+            }
+        });
+        let mut bytes = Vec::new();
+        image
+            .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Png)
+            .unwrap();
+        bytes
+    }
+}


### PR DESCRIPTION
- axum 기반 HTTP API 서버를 추가하고 /healthz, /v1/convert 엔드포인트를 구현
- multipart 업로드로 단일 이미지를 받아 기존 변환 코어를 재사용하도록 연결
- 업로드 크기, 픽셀 수, 동시 변환 수, 변환 timeout 제한을 추가
- Docker Compose api 서비스를 추가해 localhost:4000에서 로컬 서버를 실행할 수 있게 구성
- API 서버 라우터 테스트와 변환/검증 케이스를 추가
- README와 개발 문서에 로컬 API 실행법, 구조, 테스트 내용을 반영