### PR TITLE
fix: 흑백·LA 입력의 WebP 인코딩 실패 수정

### DIFF
--- a/src/converter.rs
+++ b/src/converter.rs
@@ -118,10 +118,25 @@ fn encode_to(
 ) -> Result<Vec<u8>> {
     match format {
         OutputFormat::Webp => {
-            let encoder =
-                WebpEncoder::from_image(img).map_err(|e| ConverterError::Webp(e.to_string()))?;
-            let data = encoder.encode(quality);
-            Ok(data.to_vec())
+            // webp 크레이트의 from_image 는 Luma/LumaA(흑백·LA) 와 16-bit/32F 입력에서
+            // Err("Unimplemented") 를 반환한다. 해당 모드는 RGBA8 로 정규화해 인코딩하고,
+            // RGB8/RGBA8 입력은 기존 from_rgb/from_rgba 경로를 그대로 유지한다.
+            let data = match img {
+                DynamicImage::ImageRgb8(_) | DynamicImage::ImageRgba8(_) => {
+                    let encoder = WebpEncoder::from_image(img)
+                        .map_err(|e| ConverterError::Webp(e.to_string()))?;
+                    encoder.encode(quality).to_vec()
+                }
+                other => {
+                    let rgba = other.to_rgba8();
+                    let width = rgba.width();
+                    let height = rgba.height();
+                    WebpEncoder::from_rgba(rgba.as_raw(), width, height)
+                        .encode(quality)
+                        .to_vec()
+                }
+            };
+            Ok(data)
         }
         OutputFormat::Avif => {
             let (width, height) = img.dimensions();

--- a/src/tests/integration_tests.rs
+++ b/src/tests/integration_tests.rs
@@ -59,6 +59,51 @@ fn create_test_heic_image(
 }
 
 #[test]
+fn test_webp_conversion_from_luma_alpha_input() -> Result<(), Box<dyn std::error::Error>> {
+    test_description!("LA(흑백+알파) 입력의 WebP 변환 회귀 테스트");
+    test_step!("LumaA8 PNG → WebP 변환이 Unimplemented 없이 성공하는지 확인");
+
+    let temp_dir = TempDir::new()?;
+    let input_path = temp_dir.path().join("luma_alpha.png");
+    let output_path = temp_dir.path().join("luma_alpha.webp");
+
+    // LumaA8(흑백+알파) PNG 생성 — webp 크레이트 from_image 가 거부하던 모드
+    let luma_alpha = image::GrayAlphaImage::from_fn(32, 32, |x, y| {
+        let luma = if (x + y) % 2 == 0 { 220 } else { 30 };
+        let alpha = if x < 16 { 255 } else { 128 };
+        image::LumaA([luma, alpha])
+    });
+    luma_alpha.save(&input_path)?;
+
+    // 입력이 실제로 LA 모드인지 확인 (회귀 테스트 전제 보호)
+    assert!(
+        matches!(
+            image::open(&input_path)?,
+            image::DynamicImage::ImageLumaA8(_)
+        ),
+        "테스트 입력은 LumaA8(LA) 모드여야 함"
+    );
+
+    convert_image_silent(
+        input_path.to_str().unwrap(),
+        output_path.to_str().unwrap(),
+        OutputFormat::Webp,
+        90.0,
+    )?;
+
+    assert!(output_path.exists(), "WebP 파일이 생성되어야 함");
+
+    // RIFF....WEBP 시그니처로 유효한 WebP 인지 확인
+    let bytes = fs::read(&output_path)?;
+    assert!(bytes.len() > 12, "WebP 출력이 비어 있지 않아야 함");
+    assert_eq!(&bytes[0..4], b"RIFF", "WebP RIFF 시그니처여야 함");
+    assert_eq!(&bytes[8..12], b"WEBP", "WebP 포맷 시그니처여야 함");
+    test_success!("LA 입력이 유효한 WebP 로 변환됨");
+
+    Ok(())
+}
+
+#[test]
 fn test_webp_conversion() -> Result<(), Box<dyn std::error::Error>> {
     test_description!("WebP 변환 기능 전체 테스트");
     test_step!("PNG → WebP 변환이 정상적으로 작동하는지 확인");


### PR DESCRIPTION
- webp 크레이트의 from_image 가 흑백(Luma)·흑백+알파(LumaA)·16-bit/32F 입력을 Err("Unimplemented") 로 거부해, 해당 입력의 WebP 변환이 실패(HTTP API 에서는 500)하던 문제를 수정
- 해당 모드는 RGBA8 로 정규화한 뒤 from_rgba 로 인코딩하고, RGB8/RGBA8 입력은 기존 from_image 경로를 유지해 출력 바이트를 그대로 보존
- LumaA8(LA) 입력이 유효한 WebP 로 변환되는지 확인하는 회귀 테스트 추가